### PR TITLE
Comprehension for '%' character in non-pure unit types 

### DIFF
--- a/quantities/registry.py
+++ b/quantities/registry.py
@@ -55,7 +55,7 @@ class UnitRegistry:
 
         # make sure we can parse the label ....
         if label == '': label = 'dimensionless'
-        if label == "%": label = "percent"
+	if "%" in label: label = label.replace("%", "percent")
         if label.lower() == "in": label = "inch"
 
         return self.__registry[label]


### PR DESCRIPTION
The label parser in registry.py was changed to support the '%' character in composite unit types such as '%/degC'. 