### PR TITLE
add missing mbar unit to pressure.py

### DIFF
--- a/quantities/units/pressure.py
+++ b/quantities/units/pressure.py
@@ -52,7 +52,7 @@ bar = UnitQuantity(
     100000*pascal,
     aliases=['bars']
 )
-mb = millibar = UnitQuantity(
+mbar = mb = millibar = UnitQuantity(
     'millibar',
     0.001*bar,
     symbol='mb',


### PR DESCRIPTION
make mbar an alias of millibar (https://en.wikipedia.org/wiki/Bar_(unit))

Signed-off-by: Thomas Hisch <t.hisch@gmail.com>