### PR TITLE
Remove an obsolete comment

### DIFF
--- a/quantities/markup.py
+++ b/quantities/markup.py
@@ -32,7 +32,6 @@ config = _Config()
 superscripts = ['⁰', '¹', '²', '³', '⁴', '⁵', '⁶', '⁷', '⁸', '⁹']
 
 def superscript(val):
-    # TODO: use a regexp:
     items = re.split(r'\*{2}([\d]+)(?!\.)', val)
     ret = []
     while items:


### PR DESCRIPTION
Commit 86424f12e1be503b3c6d57a1ac2317d78d337376 added a regexp to address "TODO: use a regexp", but the TODO comment didn't get removed.
