### PR TITLE
Fixes axis and out parameters on Quantity methods

### DIFF
--- a/quantities/quantity.py
+++ b/quantities/quantity.py
@@ -422,11 +422,14 @@ class Quantity(np.ndarray):
 
     @with_doc(np.ndarray.sum)
     def sum(self, axis=None, dtype=None, out=None):
-        return Quantity(
-            self.magnitude.sum(axis, dtype, out),
-            self.dimensionality,
-            copy=False
-        )
+        ret = self.magnitude.sum(axis, dtype, None if out is None else out.magnitude)
+        dim = self.dimensionality
+        if out is None:
+            return Quantity(ret, dim, copy=False)
+        if not isinstance(out, Quantity):
+            raise TypeError("out parameter must be a Quantity")
+        out._dimensionality = dim
+        return out
 
     @with_doc(np.ndarray.fill)
     def fill(self, value):
@@ -471,31 +474,44 @@ class Quantity(np.ndarray):
 
     @with_doc(np.ndarray.max)
     def max(self, axis=None, out=None):
-        return Quantity(
-            self.magnitude.max(),
-            self.dimensionality,
-            copy=False
-        )
+        ret = self.magnitude.max(axis, None if out is None else out.magnitude)
+        dim = self.dimensionality
+        if out is None:
+            return Quantity(ret, dim, copy=False)
+        if not isinstance(out, Quantity):
+            raise TypeError("out parameter must be a Quantity")
+        out._dimensionality = dim
+        return out
+
+    @with_doc(np.ndarray.argmin)
+    def argmax(self, axis=None, out=None):
+        return self.magnitude.argmax(axis, out)
 
     @with_doc(np.ndarray.min)
     def min(self, axis=None, out=None):
-        return Quantity(
-            self.magnitude.min(),
-            self.dimensionality,
-            copy=False
-        )
+        ret = self.magnitude.min(axis, None if out is None else out.magnitude)
+        dim = self.dimensionality
+        if out is None:
+            return Quantity(ret, dim, copy=False)
+        if not isinstance(out, Quantity):
+            raise TypeError("out parameter must be a Quantity")
+        out._dimensionality = dim
+        return out
 
     @with_doc(np.ndarray.argmin)
-    def argmin(self,axis=None, out=None):
-        return self.magnitude.argmin()
+    def argmin(self, axis=None, out=None):
+        return self.magnitude.argmin(axis, out)
 
     @with_doc(np.ndarray.ptp)
     def ptp(self, axis=None, out=None):
-        return Quantity(
-            self.magnitude.ptp(),
-            self.dimensionality,
-            copy=False
-        )
+        ret = self.magnitude.ptp(axis, None if out is None else out.magnitude)
+        dim = self.dimensionality
+        if out is None:
+            return Quantity(ret, dim, copy=False)
+        if not isinstance(out, Quantity):
+            raise TypeError("out parameter must be a Quantity")
+        out._dimensionality = dim
+        return out
 
     @with_doc(np.ndarray.clip)
     def clip(self, min=None, max=None, out=None):
@@ -516,23 +532,35 @@ class Quantity(np.ndarray):
             max.rescale(self._dimensionality).magnitude,
             out
         )
-        return Quantity(clipped, self.dimensionality, copy=False)
+        dim = self.dimensionality
+        if out is None:
+            return Quantity(clipped, dim, copy=False)
+        if not isinstance(out, Quantity):
+            raise TypeError("out parameter must be a Quantity")
+        out._dimensionality = dim
+        return out
 
     @with_doc(np.ndarray.round)
     def round(self, decimals=0, out=None):
-        return Quantity(
-            self.magnitude.round(decimals, out),
-            self.dimensionality,
-            copy=False
-        )
+        ret = self.magnitude.round(decimals, None if out is None else out.magnitude)
+        dim = self.dimensionality
+        if out is None:
+            return Quantity(ret, dim, copy=False)
+        if not isinstance(out, Quantity):
+            raise TypeError("out parameter must be a Quantity")
+        out._dimensionality = dim
+        return out
 
     @with_doc(np.ndarray.trace)
     def trace(self, offset=0, axis1=0, axis2=1, dtype=None, out=None):
-        return Quantity(
-            self.magnitude.trace(offset, axis1, axis2, dtype, out),
-            self.dimensionality,
-            copy=False
-        )
+        ret = self.magnitude.trace(offset, axis1, axis2, dtype, None if out is None else out.magnitude)
+        dim = self.dimensionality
+        if out is None:
+            return Quantity(ret, dim, copy=False)
+        if not isinstance(out, Quantity):
+            raise TypeError("out parameter must be a Quantity")
+        out._dimensionality = dim
+        return out
 
     @with_doc(np.ndarray.squeeze)
     def squeeze(self, axis=None):
@@ -544,26 +572,36 @@ class Quantity(np.ndarray):
 
     @with_doc(np.ndarray.mean)
     def mean(self, axis=None, dtype=None, out=None):
-        return Quantity(
-            self.magnitude.mean(axis, dtype, out),
-            self.dimensionality,
-            copy=False)
+        ret = self.magnitude.mean(axis, dtype, None if out is None else out.magnitude)
+        dim = self.dimensionality
+        if out is None:
+            return Quantity(ret, dim, copy=False)
+        if not isinstance(out, Quantity):
+            raise TypeError("out parameter must be a Quantity")
+        out._dimensionality = dim
+        return out
 
     @with_doc(np.ndarray.var)
     def var(self, axis=None, dtype=None, out=None, ddof=0):
-        return Quantity(
-            self.magnitude.var(axis, dtype, out, ddof),
-            self._dimensionality**2,
-            copy=False
-        )
+        ret = self.magnitude.var(axis, dtype, out, ddof)
+        dim = self._dimensionality**2
+        if out is None:
+            return Quantity(ret, dim, copy=False)
+        if not isinstance(out, Quantity):
+            raise TypeError("out parameter must be a Quantity")
+        out._dimensionality = dim
+        return out
 
     @with_doc(np.ndarray.std)
     def std(self, axis=None, dtype=None, out=None, ddof=0):
-        return Quantity(
-            self.magnitude.std(axis, dtype, out, ddof),
-            self._dimensionality,
-            copy=False
-        )
+        ret = self.magnitude.std(axis, dtype, out, ddof)
+        dim = self.dimensionality
+        if out is None:
+            return Quantity(ret, dim, copy=False)
+        if not isinstance(out, Quantity):
+            raise TypeError("out parameter must be a Quantity")
+        out._dimensionality = dim
+        return out
 
     @with_doc(np.ndarray.prod)
     def prod(self, axis=None, dtype=None, out=None):
@@ -572,15 +610,25 @@ class Quantity(np.ndarray):
         else:
             power = self.shape[axis]
 
-        return Quantity(
-            self.magnitude.prod(axis, dtype, out),
-            self._dimensionality**power,
-            copy=False
-        )
+        ret = self.magnitude.prod(axis, dtype, None if out is None else out.magnitude)
+        dim = self._dimensionality**power
+        if out is None:
+            return Quantity(ret, dim, copy=False)
+        if not isinstance(out, Quantity):
+            raise TypeError("out parameter must be a Quantity")
+        out._dimensionality = dim
+        return out
 
     @with_doc(np.ndarray.cumsum)
     def cumsum(self, axis=None, dtype=None, out=None):
-        return super(Quantity, self).cumsum(axis, dtype, out)*self.units
+        ret = self.magnitude.cumsum(axis, dtype, None if out is None else out.magnitude)
+        dim = self.dimensionality
+        if out is None:
+            return Quantity(ret, dim, copy=False)
+        if not isinstance(out, Quantity):
+            raise TypeError("out parameter must be a Quantity")
+        out._dimensionality = dim
+        return out
 
     @with_doc(np.ndarray.cumprod)
     def cumprod(self, axis=None, dtype=None, out=None):
@@ -589,8 +637,14 @@ class Quantity(np.ndarray):
             raise ValueError(
                 "Quantity must be dimensionless, try using simplified"
             )
-        else:
-            return super(Quantity, self).cumprod(axis, dtype, out)
+
+        ret = self.magnitude.cumprod(axis, dtype, out)
+        dim = self.dimensionality
+        if out is None:
+            return Quantity(ret, dim, copy=False)
+        if isinstance(out, Quantity):
+            out._dimensionality = dim
+        return out
 
     # list of unsupported functions: [choose]
 

--- a/quantities/tests/test_methods.py
+++ b/quantities/tests/test_methods.py
@@ -100,64 +100,167 @@ class TestQuantityMethods(TestCase):
         q = [1, 0, 5, 6, 0, 9] * pq.m
         self.assertQuantityEqual(q.nonzero()[0], [0, 2, 3, 5])
 
+    def methodWithOut(self, name, result, q=None, *args, **kw):
+        import numpy as np
+        from .. import Quantity
+
+        if q is None:
+            q = self.q
+
+        self.assertQuantityEqual(
+            getattr(q.copy(), name)(*args,**kw),
+            result
+        )
+        if isinstance(result, Quantity):
+            # deliberately using an incompatible unit
+            out = Quantity(np.empty_like(result.magnitude), pq.s, copy=False)
+        else:
+            out = np.empty_like(result)
+        ret = getattr(q.copy(), name)(*args, out=out, **kw)
+        self.assertQuantityEqual(
+            ret,
+            result
+        )
+        # returned array should be the same as out
+        self.assertEqual(id(ret),id(out))
+        # but the units had to be adjusted
+        if isinstance(result, Quantity):
+            self.assertEqual(ret.units,result.units)
+        else:
+            self.assertEqual(
+                getattr(ret, 'units', pq.dimensionless),
+                pq.dimensionless
+            )
+
+
     def test_max(self):
-        self.assertQuantityEqual(self.q.max(), 4*pq.m)
+        self.methodWithOut('max', 4 * pq.m)
+        self.methodWithOut('max', [3, 4] * pq.m, axis=0)
+        self.methodWithOut('max', [2, 4] * pq.m, axis=1)
 
     def test_argmax(self):
-        self.assertEqual(self.q.argmax(), 3)
+        import numpy as np
+        self.assertQuantityEqual(self.q.argmax(), 3)
+        self.assertQuantityEqual(self.q.argmax(axis=0), [1, 1])
+        self.assertQuantityEqual(self.q.argmax(axis=1), [1, 1])
+        # apparently, numpy's argmax does not return the same object when out is specified.
+        # instead, we test here for shared data
+        out = np.r_[0, 0]
+        ret = self.q.argmax(axis=0,out=out)
+        self.assertQuantityEqual(ret, [1, 1])
+        self.assertEqual(ret.ctypes.data, out.ctypes.data)
 
     def test_min(self):
-        self.assertEqual(self.q.min(), 1 * pq.m)
+        self.methodWithOut('min', 1 * pq.m)
+        self.methodWithOut('min', [1, 2] * pq.m, axis=0)
+        self.methodWithOut('min', [1, 3] * pq.m, axis=1)
 
     def test_argmin(self):
-        self.assertEqual(self.q.argmin(), 0)
+        import numpy as np
+        self.assertQuantityEqual(self.q.argmin(), 0)
+        self.assertQuantityEqual(self.q.argmin(axis=0), [0, 0])
+        self.assertQuantityEqual(self.q.argmin(axis=1), [0, 0])
+        # apparently, numpy's argmax does not return the same object when out is specified.
+        # instead, we test here for shared data
+        out = np.r_[2, 2]
+        ret = self.q.argmin(axis=0,out=out)
+        self.assertQuantityEqual(ret, [0, 0])
+        self.assertEqual(ret.ctypes.data, out.ctypes.data)
 
     def test_ptp(self):
-        self.assertQuantityEqual(self.q.ptp(), 3 * pq.m)
+        self.methodWithOut('ptp', 3 * pq.m)
+        self.methodWithOut('ptp', [2, 2] * pq.m, axis=0)
+        self.methodWithOut('ptp', [1, 1] * pq.m, axis=1)
 
     def test_clip(self):
-        self.assertQuantityEqual(
-            self.q.copy().clip(max=2*pq.m),
-            [[1, 2], [2, 2]] * pq.m
+        self.methodWithOut(
+            'clip',
+            [[1, 2], [2, 2]] * pq.m,
+            max=2*pq.m,
         )
-        self.assertQuantityEqual(
-            self.q.copy().clip(min=3*pq.m),
-            [[3, 3], [3, 4]] * pq.m
+        self.methodWithOut(
+            'clip',
+            [[3, 3], [3, 4]] * pq.m,
+            min=3*pq.m,
         )
-        self.assertQuantityEqual(
-            self.q.copy().clip(min=2*pq.m, max=3*pq.m),
-            [[2, 2], [3, 3]] * pq.m
+        self.methodWithOut(
+            'clip',
+            [[2, 2], [3, 3]] * pq.m,
+            min=2*pq.m, max=3*pq.m
         )
         self.assertRaises(ValueError, self.q.clip, pq.J)
         self.assertRaises(ValueError, self.q.clip, 1)
 
     def test_round(self):
         q = [1, 1.33, 5.67, 22] * pq.m
-        self.assertQuantityEqual(q.round(0), [1, 1, 6, 22] * pq.m)
-        self.assertQuantityEqual(q.round(-1), [0, 0, 10, 20] * pq.m)
-        self.assertQuantityEqual(q.round(1), [1, 1.3, 5.7, 22] * pq.m)
+        self.methodWithOut(
+            'round',
+            [1, 1, 6, 22] * pq.m,
+            q=q,
+            decimals=0,
+        )
+        self.methodWithOut(
+            'round',
+            [0, 0, 10, 20] * pq.m,
+            q=q,
+            decimals=-1,
+        )
+        self.methodWithOut(
+            'round',
+            [1, 1.3, 5.7, 22] * pq.m,
+            q=q,
+            decimals=1,
+        )
 
     def test_trace(self):
-        self.assertQuantityEqual(self.q.trace(), (1+4) * pq.m)
+        self.methodWithOut('trace', (1+4) * pq.m)
 
     def test_cumsum(self):
-        self.assertQuantityEqual(self.q.cumsum(), [1, 3, 6, 10] * pq.m)
+        self.methodWithOut('cumsum', [1, 3, 6, 10] * pq.m)
+        self.methodWithOut('cumsum', [[1, 2], [4, 6]] * pq.m, axis=0)
+        self.methodWithOut('cumsum', [[1, 3], [3, 7]] * pq.m, axis=1)
 
     def test_mean(self):
-        self.assertQuantityEqual(self.q.mean(), 2.5 * pq.m)
+        self.methodWithOut('mean', 2.5 * pq.m)
+        self.methodWithOut('mean', [2, 3] * pq.m, axis=0)
+        self.methodWithOut('mean', [1.5, 3.5] * pq.m, axis=1)
 
     def test_var(self):
-        self.assertQuantityEqual(self.q.var(), 1.25*pq.m**2)
+        self.methodWithOut('var', 1.25 * pq.m**2)
+        self.methodWithOut('var', [1, 1] * pq.m**2, axis=0)
+        self.methodWithOut('var', [0.25, 0.25] * pq.m**2, axis=1)
 
     def test_std(self):
-        self.assertQuantityEqual(self.q.std(), 1.11803*pq.m, delta=1e-5)
+        self.methodWithOut('std', 1.1180339887498949 * pq.m)
+        self.methodWithOut('std', [1, 1] * pq.m, axis=0)
+        self.methodWithOut('std', [0.5, 0.5] * pq.m, axis=1)
 
     def test_prod(self):
-        self.assertQuantityEqual(self.q.prod(), 24 * pq.m**4)
+        self.methodWithOut('prod', 24 * pq.m**4)
+        self.methodWithOut('prod', [3, 8] * pq.m**2, axis=0)
+        self.methodWithOut('prod', [2, 12] * pq.m**2, axis=1)
 
     def test_cumprod(self):
         self.assertRaises(ValueError, self.q.cumprod)
         self.assertQuantityEqual((self.q/pq.m).cumprod(), [1, 2, 6, 24])
+        q = self.q/pq.m
+        self.methodWithOut(
+            'cumprod',
+            [1, 2, 6, 24],
+            q=q,
+        )
+        self.methodWithOut(
+            'cumprod',
+            [[1, 2], [3, 8]],
+            q=q,
+            axis=0,
+        )
+        self.methodWithOut(
+            'cumprod',
+            [[1, 2], [3, 12]],
+            q=q,
+            axis=1,
+        )
 
     def test_conj(self):
         self.assertQuantityEqual((self.q*(1+1j)).conj(), self.q*(1-1j))


### PR DESCRIPTION
Most importantly, this PR fixes #69: The `axis` parameters that did not get forwarded on `min`, `max` and `ptp`. It also properly implements the `out` parameter, guaranteeing that the returned Quantity is indeed the same as the passed one.