### PR TITLE
Updated README and travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,23 @@
 language: python
+sudo: false
+env:
+  matrix:
+  - NUMPY_VERSION="1.7.1"
+  - NUMPY_VERSION="1.9.1"
 python:
   - 2.6
   - 2.7
   - 3.3
+  - 3.4
 before_install:
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then
       pip install unittest2;
     fi
-  - pip install "numpy==1.7.0"
+  - pip install "numpy==$NUMPY_VERSION"
 install:
   - python setup.py install
 script:
   - python setup.py test
+  - python -m doctest README.rst
 notifications:
   email: false

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,84 @@
+==========
+quantities
+==========
+
+|pypi version| |pypi download| |Build status|
+
+.. |pypi version| image:: https://img.shields.io/pypi/v/quantities.png
+   :target: https://pypi.python.org/pypi/quantities
+.. |pypi download| image:: https://img.shields.io/pypi/dm/quantities.png
+   :target: https://pypi.python.org/pypi/quantities
+.. |Build status| image:: https://secure.travis-ci.org/python-quantities/python-quantities.png?branch=master
+    :target: http://travis-ci.org/python-quantities/python-quantities
+
+A Python package for handling physical quantities. The source code and issue 
+tracker are hosted on github:
+
+https://www.github.com/python-quantities/python-quantities
+
+Download
+--------
+Get the latest version of quantities from
+https://pypi.python.org/pypi/quantities/
+
+To get the git version do::
+
+    $ git clone git://github.com/python-quantities/python-quantities.git
+
+
+Documentation and usage
+-----------------------
+You can find the official documenation at:
+
+ http://packages.python.org/quantities
+
+Here is a simple example:
+
+.. code:: python
+
+   >>> import quantities as pq
+   >>> distance = 42*pq.metre
+   >>> time = 17*pq.second
+   >>> velocity = distance / time
+   >>> velocity
+   array(2.4705882352941178) * m/s
+   >>> velocity + 3
+   Traceback (most recent call last):
+     ...
+   ValueError: Unable to convert between units of "dimensionless" and "m/s"
+
+Installation
+------------
+quantities has a hard dependency on the `NumPy <http://www.numpy.org>`_ library.
+You should install it first, please refer to the NumPy installation guide:
+
+http://docs.scipy.org/doc/numpy/user/install.html
+
+To install quantities itself, then simply run::
+
+    $ python setup.py install --user
+
+If you install it system-wide, you may need to prefix the previous command with ``sudo``::
+
+    $ sudo python setup.py install
+
+Tests
+-----
+To execute all tests, run::
+
+    $ python setup.py test
+
+in the current directory. The master branch is automatically tested by
+Travis CI.
+
+Author
+------
+quantities is written by Darren Dale
+
+License
+-------
+Quantities only uses BSD compatible code.  See the Open Source
+Initiative `licenses page <http://www.opensource.org/licenses>`_
+for details on individual licenses.
+
+See `doc/user/license.rst <doc/user/license.rst>`_ for further details on the license of quantities

--- a/README.txt
+++ b/README.txt
@@ -1,3 +1,0 @@
-to install quantities, run the following in the source directory:
-
-python setup.py install


### PR DESCRIPTION
This is a minor PR for updating the README and travis test script.

Changes to travis script:

- Also test for Python 3.4
- Change tested version of `numpy` from v1.7.0 to:
    - v1.7.1
    - v1.9.1

To see what the proposed README.rst renders like, see:
https://github.com/bjodah/python-quantities/tree/update_readme_travis
