### PR TITLE
Fix python3.5 regression (raising to the zeroth power)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,12 @@ sudo: false
 env:
   matrix:
   - NUMPY_VERSION="1.8.2"
-  - NUMPY_VERSION="1.9.1"
+  - NUMPY_VERSION="1.11.2"
 python:
   - 2.6
   - 2.7
-  - 3.3
   - 3.4
+  - 3.5
 before_install:
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then
       pip install unittest2;

--- a/quantities/dimensionality.py
+++ b/quantities/dimensionality.py
@@ -320,7 +320,6 @@ p_dict[np.absolute] = _d_copy
 p_dict[np.conjugate] = _d_copy
 p_dict[np.negative] = _d_copy
 p_dict[np.ones_like] = _d_copy
-p_dict[np.core.umath._ones_like] = _d_copy
 p_dict[np.rint] = _d_copy
 p_dict[np.floor] = _d_copy
 p_dict[np.fix] = _d_copy

--- a/quantities/dimensionality.py
+++ b/quantities/dimensionality.py
@@ -320,6 +320,7 @@ p_dict[np.absolute] = _d_copy
 p_dict[np.conjugate] = _d_copy
 p_dict[np.negative] = _d_copy
 p_dict[np.ones_like] = _d_copy
+p_dict[np.core.umath._ones_like] = _d_copy
 p_dict[np.rint] = _d_copy
 p_dict[np.floor] = _d_copy
 p_dict[np.fix] = _d_copy

--- a/quantities/quantity.py
+++ b/quantities/quantity.py
@@ -318,7 +318,7 @@ class Quantity(np.ndarray):
     @with_doc(np.ndarray.__pow__)
     @check_uniform
     def __pow__(self, other):
-        return super(Quantity, self).__pow__(other)
+        return np.power(self, other)
 
     @with_doc(np.ndarray.__ipow__)
     @check_uniform

--- a/quantities/tests/test_arithmetic.py
+++ b/quantities/tests/test_arithmetic.py
@@ -363,6 +363,7 @@ class TestDTypes(TestCase):
     def test_powering(self):
         # test raising a quantity to a power
         self.assertQuantityEqual((5.5 * pq.cm)**5, (5.5**5) * (pq.cm**5))
+        self.assertQuantityEqual((5.5 * pq.cm)**0, (5.5**0) * pq.dimensionless)
 
         # must also work with compound units
         self.assertQuantityEqual((5.5 * pq.J)**5, (5.5**5) * (pq.J**5))

--- a/quantities/unitquantity.py
+++ b/quantities/unitquantity.py
@@ -514,4 +514,3 @@ def set_default_units(
     UnitSubstance.set_default_unit(substance)
     UnitTemperature.set_default_unit(temperature)
     UnitTime.set_default_unit(time)
-


### PR DESCRIPTION
I don't see this on Python 2. Hopefully reproducible on Travis.