### PR TITLE
Add additional information units

### DIFF
--- a/quantities/tests/test_conversion.py
+++ b/quantities/tests/test_conversion.py
@@ -55,3 +55,41 @@ class TestDefaultUnits(TestCase):
         pq.set_default_units('cgs', length='mm')
         self.assertQuantityEqual(pq.kg.simplified, 1000*pq.g)
         self.assertQuantityEqual(pq.m.simplified, 1000*pq.mm)
+
+class TestUnitInformation(TestCase):
+
+    def test_si(self):
+        pq.set_default_units(information='B')
+        self.assertQuantityEqual(pq.kB.simplified, pq.B*pq.kilo)
+        self.assertQuantityEqual(pq.MB.simplified, pq.B*pq.mega)
+        self.assertQuantityEqual(pq.GB.simplified, pq.B*pq.giga)
+        self.assertQuantityEqual(pq.TB.simplified, pq.B*pq.tera)
+        self.assertQuantityEqual(pq.PB.simplified, pq.B*pq.peta)
+        self.assertQuantityEqual(pq.EB.simplified, pq.B*pq.exa)
+        self.assertQuantityEqual(pq.ZB.simplified, pq.B*pq.zetta)
+        self.assertQuantityEqual(pq.YB.simplified, pq.B*pq.yotta)
+
+    def test_si_aliases(self):
+        prefixes = ['kilo', 'mega', 'giga', 'tera', 'peta', 'exa', 'zetta', 'yotta']
+        for prefix in prefixes:
+            self.assertQuantityEqual(pq.B.rescale(prefix + 'byte'), pq.B.rescale(prefix + 'bytes'))
+            self.assertQuantityEqual(pq.B.rescale(prefix + 'byte'), pq.B.rescale(prefix + 'octet'))
+            self.assertQuantityEqual(pq.B.rescale(prefix + 'byte'), pq.B.rescale(prefix + 'octets'))
+
+    def test_iec(self):
+        pq.set_default_units(information='B')
+        self.assertQuantityEqual(pq.KiB.simplified, pq.B*pq.kibi)
+        self.assertQuantityEqual(pq.MiB.simplified, pq.B*pq.mebi)
+        self.assertQuantityEqual(pq.GiB.simplified, pq.B*pq.gibi)
+        self.assertQuantityEqual(pq.TiB.simplified, pq.B*pq.tebi)
+        self.assertQuantityEqual(pq.PiB.simplified, pq.B*pq.pebi)
+        self.assertQuantityEqual(pq.EiB.simplified, pq.B*pq.exbi)
+        self.assertQuantityEqual(pq.ZiB.simplified, pq.B*pq.zebi)
+        self.assertQuantityEqual(pq.YiB.simplified, pq.B*pq.yobi)
+
+    def test_iec_aliases(self):
+        prefixes = ['kibi', 'mebi', 'gibi', 'tebi', 'pebi', 'exbi', 'zebi', 'yobi']
+        for prefix in prefixes:
+            self.assertQuantityEqual(pq.B.rescale(prefix + 'byte'), pq.B.rescale(prefix + 'bytes'))
+            self.assertQuantityEqual(pq.B.rescale(prefix + 'byte'), pq.B.rescale(prefix + 'octet'))
+            self.assertQuantityEqual(pq.B.rescale(prefix + 'byte'), pq.B.rescale(prefix + 'octets'))

--- a/quantities/units/information.py
+++ b/quantities/units/information.py
@@ -15,10 +15,108 @@ B = byte = o = octet = UnitInformation(
     symbol='B',
     aliases=['bytes', 'o', 'octet', 'octets']
 )
+kB = kilobyte = ko = UnitInformation(
+    'kilobyte',
+    1000 * byte,
+    symbol='kB',
+    aliases=['kilobytes', 'kilooctet', 'kilooctets']
+)
+MB = megabyte = Mo = UnitInformation(
+    'megabyte',
+    1000 * kilobyte,
+    symbol='MB',
+    aliases=['megabytes', 'megaoctet', 'megaoctets']
+)
+GB = gigabyte = Go = UnitInformation(
+    'gigabyte',
+    1000 * megabyte,
+    symbol='GB',
+    aliases=['gigabytes', 'gigaoctet', 'gigaoctets']
+)
+TB = terabyte = To = UnitInformation(
+    'terabyte',
+    1000 * gigabyte,
+    symbol='TB',
+    aliases=['terabytes', 'teraoctet', 'teraoctets']
+)
+PB = petabyte = Po = UnitInformation(
+    'petabyte',
+    1000 * terabyte,
+    symbol='PB',
+    aliases=['petabytes', 'petaoctet', 'petaoctets']
+)
+EB = exabyte = Eo = UnitInformation(
+    'exabyte',
+    1000 * petabyte,
+    symbol='EB',
+    aliases=['exabytes', 'exaoctet', 'exaoctets']
+)
+ZB = zettabyte = Zo = UnitInformation(
+    'zettabyte',
+    1000 * exabyte,
+    symbol='ZB',
+    aliases=['zettabytes', 'zettaoctet', 'zettaoctets']
+)
+YB = yottabyte = Yo = UnitInformation(
+    'yottabyte',
+    1000 * zettabyte,
+    symbol='YB',
+    aliases=['yottabytes', 'yottaoctet', 'yottaoctets']
+)
 Bd = baud = bps = UnitQuantity(
     'baud',
     bit/s,
     symbol='Bd',
+)
+
+# IEC
+KiB = kibibyte = Kio = UnitInformation(
+    'kibibyte',
+    1024 * byte,
+    symbol='KiB',
+    aliases=['kibibytes', 'kibioctet', 'kibioctets']
+)
+MiB = mebibyte = Mio = UnitInformation(
+    'mebibyte',
+    1024 * kibibyte,
+    symbol='MiB',
+    aliases=['mebibytes', 'mebioctet', 'mebioctets']
+)
+GiB = gibibyte = Gio = UnitInformation(
+    'gibibyte',
+    1024 * mebibyte,
+    symbol='GiB',
+    aliases=['gibibytes', 'gibioctet', 'gibioctets']
+)
+TiB = tebibyte = Tio = UnitInformation(
+    'tebibyte',
+    1024 * gibibyte,
+    symbol='TiB',
+    aliases=['tebibytes', 'tebioctet', 'tebioctets']
+)
+PiB = pebibyte = Pio = UnitInformation(
+    'pebibyte',
+    1024 * tebibyte,
+    symbol='PiB',
+    aliases=['pebibytes', 'pebioctet', 'pebioctets']
+)
+EiB = exbibyte = Eio = UnitInformation(
+    'exbibyte',
+    1024 * pebibyte,
+    symbol='EiB',
+    aliases=['exbibytes', 'exbioctet', 'exbioctets']
+)
+ZiB = zebibyte = Zio = UnitInformation(
+    'zebibyte',
+    1024 * exbibyte,
+    symbol='ZiB',
+    aliases=['zebibytes', 'zebioctet', 'zebioctets']
+)
+YiB = yobibyte = Yio = UnitInformation(
+    'yobibyte',
+    1024 * zebibyte,
+    symbol='YiB',
+    aliases=['yobibytes', 'yobioctet', 'yobioctets']
 )
 
 del UnitQuantity, s, dimensionless


### PR DESCRIPTION
This PR adds SI multiples for the byte unit (kB, MB, ...) and the IEC units (KiB, MiB...).
It refers to issue #142.