### PR TITLE
Change comparison of Quantity (to fix gh-146)

### DIFF
--- a/quantities/tests/test_comparison.py
+++ b/quantities/tests/test_comparison.py
@@ -19,6 +19,8 @@ class TestComparison(TestCase):
         self.assertEqual(pq.J == 2*pq.kg*pq.m**2/pq.s**2, [False])
 
         self.assertEqual(pq.J == pq.kg, [False])
+        self.assertTrue(1e3*pq.m == pq.km)
+        self.assertFalse(1e3*pq.m == [1e3])
 
     def test_scalar_inequality(self):
         self.assertEqual(pq.J != pq.erg, [True])
@@ -66,7 +68,7 @@ class TestComparison(TestCase):
         )
         self.assertQuantityEqual(
             [1, 2, 3, 4]*pq.J == [1, 22, 3, 44],
-            [1, 0, 1, 0]
+            [0, 0, 0, 0]
         )
 
     def test_array_inequality(self):
@@ -80,7 +82,7 @@ class TestComparison(TestCase):
         )
         self.assertQuantityEqual(
             [1, 2, 3, 4]*pq.J != [1, 22, 3, 44],
-            [0, 1, 0, 1]
+            [1, 1, 1, 1]
         )
 
     def test_quantity_less_than(self):
@@ -92,9 +94,11 @@ class TestComparison(TestCase):
             [50, 100, 150]*pq.cm < [1, 1, 1]*pq.m,
             [1, 0, 0]
         )
-        self.assertQuantityEqual(
-            [1, 2, 33]*pq.J < [1, 22, 3],
-            [0, 1, 0]
+        self.assertRaises(
+            ValueError,
+            op.lt,
+            [1, 2, 33]*pq.J,
+            [1, 22, 3]
         )
         self.assertRaises(
             ValueError,
@@ -112,9 +116,11 @@ class TestComparison(TestCase):
             [50, 100, 150]*pq.cm <= [1, 1, 1]*pq.m,
             [1, 1, 0]
         )
-        self.assertQuantityEqual(
-            [1, 2, 33]*pq.J <= [1, 22, 3],
-            [1, 1, 0]
+        self.assertRaises(
+            ValueError,
+            op.le,
+            [1, 2, 33]*pq.J,
+            [1, 22, 3]
         )
         self.assertRaises(
             ValueError,
@@ -132,9 +138,11 @@ class TestComparison(TestCase):
             [50, 100, 150]*pq.cm >= [1, 1, 1]*pq.m,
             [0, 1, 1]
         )
-        self.assertQuantityEqual(
-            [1, 2, 33]*pq.J >= [1, 22, 3],
-            [1, 0, 1]
+        self.assertRaises(
+            ValueError,
+            op.ge,
+            [1, 2, 33]*pq.J,
+            [1, 22, 3]
         )
         self.assertRaises(
             ValueError,
@@ -152,13 +160,15 @@ class TestComparison(TestCase):
             [50, 100, 150]*pq.cm > [1, 1, 1]*pq.m,
             [0, 0, 1]
         )
-        self.assertQuantityEqual(
-            [1, 2, 33]*pq.J > [1, 22, 3],
-            [0, 0, 1]
+        self.assertRaises(
+            ValueError,
+            op.gt,
+            [1, 2, 33]*pq.J,
+            [1, 22, 3]
         )
         self.assertRaises(
             ValueError,
             op.gt,
             [1, 2, 33]*pq.J,
-            [1, 22, 3]*pq.kg,
+            [1, 22, 3]*pq.kg
         )

--- a/quantities/tests/test_umath.py
+++ b/quantities/tests/test_umath.py
@@ -151,17 +151,13 @@ class TestUmath(TestCase):
             [-1., -1., -0., 1., 2., 2., 2.] * pq.m
             )
 
-    @unittest.expectedFailure
     def test_fix(self):
-        try:
-            self.assertQuantityEqual(np.fix(3.14 * pq.degF), 3.0 * pq.degF)
-            self.assertQuantityEqual(np.fix(3.0 * pq.degF), 3.0 * pq.degF)
-            self.assertQuantityEqual(
-                np.fix([2.1, 2.9, -2.1, -2.9] * pq.degF),
-                [2., 2., -2., -2.] * pq.degF
-                )
-        except ValueError as e:
-            raise self.failureException(e)
+        self.assertQuantityEqual(np.fix(3.14 * pq.degF), 3.0 * pq.degF)
+        self.assertQuantityEqual(np.fix(3.0 * pq.degF), 3.0 * pq.degF)
+        self.assertQuantityEqual(
+            np.fix([2.1, 2.9, -2.1, -2.9] * pq.degF),
+            [2., 2., -2., -2.] * pq.degF
+        )
 
     def test_exp(self):
         self.assertQuantityEqual(np.exp(1*pq.dimensionless), np.e)

--- a/quantities/tests/test_umath.py
+++ b/quantities/tests/test_umath.py
@@ -151,13 +151,17 @@ class TestUmath(TestCase):
             [-1., -1., -0., 1., 2., 2., 2.] * pq.m
             )
 
+    @unittest.expectedFailure
     def test_fix(self):
-        self.assertQuantityEqual(np.fix(3.14 * pq.degF), 3.0 * pq.degF)
-        self.assertQuantityEqual(np.fix(3.0 * pq.degF), 3.0 * pq.degF)
-        self.assertQuantityEqual(
-            np.fix([2.1, 2.9, -2.1, -2.9] * pq.degF),
-            [2., 2., -2., -2.] * pq.degF
-        )
+        try:
+            self.assertQuantityEqual(np.fix(3.14 * pq.degF), 3.0 * pq.degF)
+            self.assertQuantityEqual(np.fix(3.0 * pq.degF), 3.0 * pq.degF)
+            self.assertQuantityEqual(
+                np.fix([2.1, 2.9, -2.1, -2.9] * pq.degF),
+                [2., 2., -2., -2.] * pq.degF
+            )
+        except ValueError as e:
+            raise self.failureException(e)
 
     def test_exp(self):
         self.assertQuantityEqual(np.exp(1*pq.dimensionless), np.e)

--- a/quantities/umath.py
+++ b/quantities/umath.py
@@ -81,7 +81,7 @@ def gradient(f, *varargs):
                       for i,j  in zip( ret, varargsQuantities)])
 
 @with_doc(np.cross)
-def cross (a, b , axisa=-1, axisb=-1, axisc=-1, axis=None):
+def cross(a, b , axisa=-1, axisb=-1, axisc=-1, axis=None):
     if not (isinstance(a, Quantity) and isinstance(b, Quantity)):
         return np.cross(a, b, axisa, axisb, axisc, axis)
 


### PR DESCRIPTION
This fixes gh-146 (Quantity with dimension comparing equal to plain numpy arrays).
This is a rather big change since it actually changes some tests to expect errors being raised where equality was assumed before. So we might need a deprecation cycle (we can emit warnings where we will raise exceptions / change equality behaviour). Or maybe people even find the change to be too large to even be considered?

What do people think?