### PR TITLE
Fix broken support for pq.Quantity('mbar')

### DIFF
--- a/quantities/units/pressure.py
+++ b/quantities/units/pressure.py
@@ -56,6 +56,7 @@ mb = mbar = millibar = UnitQuantity(
     'millibar',
     0.001*bar,
     symbol='mb',
+    aliases=['mbar']
 )
 kbar = kilobar = UnitQuantity(
     'kilobar',


### PR DESCRIPTION
Fix support for the unit mbar that was introduced in #72. The problem
with mbar is that pq.Quanitty('mbar') raises a LookupError without this
fix.