### PR TITLE
Add a __format__ implementation for Quantity

### DIFF
--- a/quantities/quantity.py
+++ b/quantities/quantity.py
@@ -359,6 +359,16 @@ class Quantity(np.ndarray):
             dims = self.dimensionality.string
         return '%s %s'%(str(self.magnitude), dims)
 
+    if tuple(map(int, np.__version__.split('.')[:2])) >= (1, 14):
+        # in numpy 1.14 the formatting of scalar values was changed
+        # see https://github.com/numpy/numpy/pull/9883
+
+        def __format__(self, format_spec):
+            ret = super(Quantity, self).__format__(format_spec)
+            if self.ndim:
+                return ret
+            return ret + ' {}'.format(self.dimensionality)
+
     @with_doc(np.ndarray.__getitem__)
     def __getitem__(self, key):
         ret = super(Quantity, self).__getitem__(key)

--- a/quantities/tests/test_formatting.py
+++ b/quantities/tests/test_formatting.py
@@ -1,0 +1,17 @@
+from .. import units as pq
+from .common import TestCase
+
+
+class TestFormatting(TestCase):
+
+    @staticmethod
+    def _check(quantity, formatted):
+        assert str(quantity) == formatted
+        assert '{}'.format(quantity) == formatted
+        assert '{!s}'.format(quantity) == formatted
+
+    def test_str_format_scalar(self):
+        self._check(1*pq.J, '1.0 J')
+
+    def test_str_format_non_scalar(self):
+        self._check([1, 2]*pq.J, '[1. 2.] J')


### PR DESCRIPTION
Closes #156

This fix is a slightly adapted version of
https://github.com/yt-project/unyt/commit/e57e1ecc1214deee36ba679f08ee46c6aa6aefbe

If we want to keep support for older versions of numpy we have to add a
numpy version check. For simplicity I dropped support for older versions
of numpy. I hope that this is fine.

Edit: Added the numpy version check.