### PR TITLE
dimensionality fix for OrderedDict for Python 2.7. Issue #167

### DIFF
--- a/quantities/dimensionality.py
+++ b/quantities/dimensionality.py
@@ -11,6 +11,7 @@ import numpy as np
 from . import markup
 from .registry import unit_registry
 from .decorators import memoize
+from collections import OrderedDict
 
 def assert_isinstance(obj, types):
     try:
@@ -21,7 +22,7 @@ def assert_isinstance(obj, types):
         )
 
 
-class Dimensionality(dict):
+class Dimensionality(OrderedDict):
 
     """
     """


### PR DESCRIPTION
Here's the change proposed for #167. This fixed the issue and passed tests when I was testing it locally. Please approve and release as soon as feasible. This has become critical for us again. Thanks!