### PR TITLE
Add dimensionless unit 'lsb'

### DIFF
--- a/quantities/units/dimensionless.py
+++ b/quantities/units/dimensionless.py
@@ -17,4 +17,11 @@ count = counts = UnitQuantity(
     aliases=['cts', 'counts']
 )
 
+lsb = UnitQuantity(
+    'least_significant_bit',
+    1*dimensionless,
+    symbol='lsb',
+    aliases=['lsbs']
+)
+
 del UnitQuantity


### PR DESCRIPTION
The dimensionless qualifier 'lsb' (least significant bit) is commonly used  when describing the behavior of electronic instruments, especially in the context of A/D and D/A converters. It denotes a given change of the digital value in units of the smallest possible change – one LSB.