### PR TITLE
Fixed non-list tolist() bug

### DIFF
--- a/quantities/quantity.py
+++ b/quantities/quantity.py
@@ -461,7 +461,10 @@ class Quantity(np.ndarray):
         #first get a dummy array from the ndarray method
         work_list = self.magnitude.tolist()
         #now go through and replace all numbers with the appropriate Quantity
-        self._tolist(work_list)
+        if isinstance(work_list, list):
+            self._tolist(work_list)
+        else:
+            work_list = Quantity(work_list, self.dimensionality)
         return work_list
 
     def _tolist(self, work_list):


### PR DESCRIPTION
Fixes #185.

```
import sys
sys.path.insert(0, '/home/rgerkin/Dropbox/dev/quantities')
import numpy as np
import quantities as pq

x = np.array([1.0, 2.0])
y = np.array(3.0)

x.tolist()  # Works fine
y.tolist() # Works fine

(x * pq.V).tolist() # Works fine
(y * pq.V).tolist() # Throws exception (fixed by this PR).
```