### PR TITLE
Extend the testing matrix to NEP29 + 1 year

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ "3.7", "3.8", "3.9" ]
-        numpy-version: [ "1.18", "1.19", "1.20", "1.21" ]
+        python-version: [ "3.7", "3.8", "3.9", "3.10" ]
+        numpy-version: [ "1.16", "1.17", "1.18", "1.19", "1.20", "1.21" ]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,22 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ "3.7", "3.8", "3.9", "3.10" ]
+        python-version: [ "3.7", "3.8", "3.9" ]
         numpy-version: [ "1.16", "1.17", "1.18", "1.19", "1.20", "1.21" ]
-
+        exclude:
+          - python-version: "3.9"
+            numpy-version: "1.16"
+            os: ubuntu-latest
+          - python-version: "3.9"
+            numpy-version: "1.17"
+            os: ubuntu-latest
+          - python-version: "3.8"
+            numpy-version: "1.17"
+            os: ubuntu-latest
+        include:
+          - python-version: "3.10"
+            numpy-version: "1.21"
+            os: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 

--- a/doc/user/installation.rst
+++ b/doc/user/installation.rst
@@ -9,7 +9,7 @@ Prerequisites
 Quantities has a few dependencies:
 
 * Python_ (>=3.7)
-* NumPy_ (>=1.18)
+* NumPy_ (>=1.16)
 
 
 Source Code Installation

--- a/doc/user/installation.rst
+++ b/doc/user/installation.rst
@@ -11,6 +11,8 @@ Quantities has a few dependencies:
 * Python_ (>=3.7)
 * NumPy_ (>=1.16)
 
+(bearing in mind that not all combinations of Python and NumPy versions necessarily work).
+
 
 Source Code Installation
 ========================

--- a/quantities/markup.py
+++ b/quantities/markup.py
@@ -100,7 +100,7 @@ def format_units_latex(udict,font='mathrm',mult=r'\\cdot',paren=False):
     By default this is the latex \\cdot symbol.  Other useful
     options may be '' or '*'.
 
-    If paren=True, encapsulate the string in '\\left(' and '\right)'
+    If paren=True, encapsulate the string in '\\left(' and '\\right)'
 
     The result of format_units_latex is encapsulated in $.  This allows the result
     to be used directly in Latex in normal text mode, or in Matplotlib text via the

--- a/setup.py
+++ b/setup.py
@@ -137,7 +137,7 @@ setup(
     platforms = 'Any',
     requires = [
         'python (>=3.7)',
-        'numpy (>=1.18)',
+        'numpy (>=1.16)',
         ],
     url = 'http://python-quantities.readthedocs.io/',
     version = versioneer.get_version(),


### PR DESCRIPTION
i.e. continue to support Python/NumPy versions for one year longer than [NEP29](https://numpy.org/neps/nep-0029-deprecation_policy.html) recommends.

(see discussion in #195)