### PR TITLE
docs: Fix a few typos

### DIFF
--- a/doc/devel/documenting.rst
+++ b/doc/devel/documenting.rst
@@ -257,7 +257,7 @@ and refer to it using  the standard reference syntax::
 
 Keep in mind that we may want to reorganize the contents later, so
 let's avoid top level names in references like ``user`` or ``devel``
-or ``faq`` unless necesssary, because for example the FAQ "what is a
+or ``faq`` unless necessary, because for example the FAQ "what is a
 backend?" could later become part of the users guide, so the label::
 
     .. _what-is-a-backend
@@ -286,7 +286,7 @@ Emacs helpers
 
 There is an emacs mode `rst.el
 <http://docutils.sourceforge.net/tools/editors/emacs/rst.el>`_ which
-automates many important ReST tasks like building and updateing
+automates many important ReST tasks like building and updating
 table-of-contents, and promoting or demoting section headings.  Here
 is the basic ``.emacs`` configuration::
 

--- a/quantities/decorators.py
+++ b/quantities/decorators.py
@@ -104,7 +104,7 @@ def quantitizer(base_function,
         #convert the list back to a tuple so it can be used as an output
         args = tuple (args)
 
-        #repalce all the quantities in the keyword argument
+        #replace all the quantities in the keyword argument
         #dictionary with ndarrays
         for i in kwargs:
             #test if the argument is a quantity

--- a/quantities/quantity.py
+++ b/quantities/quantity.py
@@ -11,7 +11,7 @@ from .dimensionality import Dimensionality, p_dict
 from .registry import unit_registry
 from .decorators import with_doc
 
-PREFERRED = []  # List of preferred quanitities for each symbol,
+PREFERRED = []  # List of preferred quantities for each symbol,
                 # e.g. PREFERRED = [pq.mV, pq.pA, pq.UnitQuantity('femtocoulomb', 1e-15*pq.C, 'fC')]
                 # Intended to be overwritten in down-stream packages
 

--- a/quantities/umath.py
+++ b/quantities/umath.py
@@ -57,7 +57,7 @@ def ediff1d(ary, to_end=None, to_begin=None):
 @with_doc(np.gradient)
 def gradient(f, *varargs):
     # if no sample distances are specified, use dimensionless 1
-    # this mimicks the behavior of np.gradient, but perhaps we should
+    # this mimics the behavior of np.gradient, but perhaps we should
     # remove this default behavior
     # removed for now::
     #


### PR DESCRIPTION
There are small typos in:
- doc/devel/documenting.rst
- quantities/decorators.py
- quantities/quantity.py
- quantities/umath.py

Fixes:
- Should read `updating` rather than `updateing`.
- Should read `replace` rather than `repalce`.
- Should read `quantities` rather than `quanitities`.
- Should read `necessary` rather than `necesssary`.
- Should read `mimics` rather than `mimicks`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md