### PR TITLE
Remove deprecated mb as symbol for millibar unit

### DIFF
--- a/quantities/units/pressure.py
+++ b/quantities/units/pressure.py
@@ -51,11 +51,11 @@ bar = UnitQuantity(
     100000*pascal,
     aliases=['bars']
 )
-mb = mbar = millibar = UnitQuantity(
+mbar = millibar = UnitQuantity(
     'millibar',
     0.001*bar,
-    symbol='mb',
-    aliases=['mbar']
+    symbol='mbar',
+    aliases=['millibars']
 )
 kbar = kilobar = UnitQuantity(
     'kilobar',


### PR DESCRIPTION
In order to be consistent with the other pressure units that are derived
from the unit bar, we should use mbar as the symbol for millibar. The
symbol mb, which is a deprecated symbol, because the b in mb conflicts
with the metric unit barn, was removed. Since the other bar units also
define an alias with a written out SI prefix, this change also adds the
unit "millibars" as an alias for mbar.

https://en.wikipedia.org/wiki/Bar_(unit)#Origin Also mentions that b is
a deprecated symbol for bar.