### PR TITLE
Preserve dtype in rescale

### DIFF
--- a/quantities/dimensionality.py
+++ b/quantities/dimensionality.py
@@ -367,6 +367,7 @@ p_dict[np.log10] = _d_dimensionless
 p_dict[np.log2] = _d_dimensionless
 p_dict[np.log1p] = _d_dimensionless
 p_dict[np.exp] = _d_dimensionless
+p_dict[np.exp2] = _d_dimensionless
 p_dict[np.expm1] = _d_dimensionless
 p_dict[np.logaddexp] = _d_dimensionless
 p_dict[np.logaddexp2] = _d_dimensionless

--- a/quantities/quantity.py
+++ b/quantities/quantity.py
@@ -247,9 +247,9 @@ class Quantity(np.ndarray):
         # might be related to numpy ticket # 826
         if not isinstance(ret, type(self)):
             if self.__array_priority__ >= Quantity.__array_priority__:
-                ret = type(self)(ret, self._dimensionality)
+                ret = type(self)(ret, self._dimensionality, dtype=self.dtype)
             else:
-                ret = Quantity(ret, self._dimensionality)
+                ret = Quantity(ret, self._dimensionality, dtype=self.dtype)
 
         return ret
 

--- a/quantities/quantity.py
+++ b/quantities/quantity.py
@@ -198,7 +198,7 @@ class Quantity(np.ndarray):
         """
         Return a copy of the quantity converted to the specified units.
         If `units` is `None`, an attempt will be made to rescale the quantity
-        to preferred units (see `rescale_preferred`).  
+        to preferred units (see `rescale_preferred`).
         """
         if units is None:
             try:
@@ -217,8 +217,8 @@ class Quantity(np.ndarray):
                 'Unable to convert between units of "%s" and "%s"'
                 %(from_u._dimensionality, to_u._dimensionality)
             )
-        return Quantity(cf*self.magnitude, to_u)
-    
+        return Quantity(cf*self.magnitude, to_u, dtype=self.dtype)
+
     def rescale_preferred(self):
         """
         Return a copy of the quantity converted to the preferred units and scale.
@@ -238,7 +238,7 @@ class Quantity(np.ndarray):
                 return self.rescale(preferred)
         raise Exception("Preferred units for '%s' (or equivalent) not specified in "
                         "quantites.quantity.PREFERRED." % self.dimensionality)
-        
+
     @with_doc(np.ndarray.astype)
     def astype(self, dtype=None, **kwargs):
         '''Scalars are returned as scalar Quantity arrays.'''

--- a/quantities/quantity.py
+++ b/quantities/quantity.py
@@ -59,7 +59,7 @@ def scale_other_units(f):
         if not isinstance(other, Quantity):
             other = other.view(type=Quantity)
         if other._dimensionality != self._dimensionality:
-            other = other.rescale(self.units)
+            other = other.rescale(self.units, dtype=np.result_type(self.dtype, other.dtype))
         return f(self, other, *args)
     return g
 

--- a/quantities/quantity.py
+++ b/quantities/quantity.py
@@ -194,7 +194,7 @@ class Quantity(np.ndarray):
         mag *= cf
         self._dimensionality = to_u.dimensionality
 
-    def rescale(self, units=None):
+    def rescale(self, units=None, dtype=None):
         """
         Return a copy of the quantity converted to the specified units.
         If `units` is `None`, an attempt will be made to rescale the quantity
@@ -206,8 +206,10 @@ class Quantity(np.ndarray):
             except Exception as e:
                 raise Exception('No argument passed to `.rescale` and %s' % e)
         to_dims = validate_dimensionality(units)
+        if dtype is None:
+            dtype = self.dtype
         if self.dimensionality == to_dims:
-            return self.astype(self.dtype)
+            return self.astype(dtype)
         to_u = Quantity(1.0, to_dims)
         from_u = Quantity(1.0, self.dimensionality)
         try:
@@ -217,7 +219,7 @@ class Quantity(np.ndarray):
                 'Unable to convert between units of "%s" and "%s"'
                 %(from_u._dimensionality, to_u._dimensionality)
             )
-        return Quantity(cf*self.magnitude, to_u, dtype=self.dtype)
+        return Quantity(cf*self.magnitude, to_u, dtype=dtype)
 
     def rescale_preferred(self):
         """
@@ -398,7 +400,9 @@ class Quantity(np.ndarray):
         if not isinstance(value, Quantity):
             value = Quantity(value)
         if self._dimensionality != value._dimensionality:
-            value = value.rescale(self._dimensionality)
+            # Setting `dtype` to 'd' is done to ensure backwards
+            # compatibility, arguably it's questionable design.
+            value = value.rescale(self._dimensionality, dtype='d')
         self.magnitude[key] = value
 
     @with_doc(np.ndarray.__lt__)
@@ -494,15 +498,17 @@ class Quantity(np.ndarray):
             pass
 
     @with_doc(np.ndarray.put)
-    def put(self, indicies, values, mode='raise'):
+    def put(self, indicies, values, mode='raise', dtype='d'):
         """
         performs the equivalent of ndarray.put() but enforces units
         values - must be an Quantity with the same units as self
         """
+        # The default of `dtype` is set to 'd' to ensure backwards
+        # compatibility, arguably it's questionable design.
         if not isinstance(values, Quantity):
             values = Quantity(values)
         if values._dimensionality != self._dimensionality:
-            values = values.rescale(self.units)
+            values = values.rescale(self.units, dtype=dtype)
         self.magnitude.put(indicies, values, mode)
 
     # choose does not function correctly, and it is not clear

--- a/quantities/tests/test_arithmetic.py
+++ b/quantities/tests/test_arithmetic.py
@@ -358,6 +358,12 @@ class TestDTypes(TestCase):
         self.assertRaises(ValueError, op.isub, [1, 2, 3]*pq.m, pq.J)
         self.assertRaises(ValueError, op.isub, [1, 2, 3]*pq.m, 5*pq.J)
 
+    def test_division(self):
+        molar = pq.UnitQuantity('M',  1e3 * pq.mole/pq.m**3, u_symbol='M')
+        for subtr in [1, 1.0]:
+            q = 1*molar/(1000*pq.mole/pq.m**3)
+            self.assertQuantityEqual((q - subtr).simplified, 0)
+
     def test_powering(self):
         # test raising a quantity to a power
         self.assertQuantityEqual((5.5 * pq.cm)**5, (5.5**5) * (pq.cm**5))

--- a/quantities/tests/test_arithmetic.py
+++ b/quantities/tests/test_arithmetic.py
@@ -359,7 +359,7 @@ class TestDTypes(TestCase):
         self.assertRaises(ValueError, op.isub, [1, 2, 3]*pq.m, 5*pq.J)
 
     def test_division(self):
-        molar = pq.UnitQuantity('M',  1e3 * pq.mole/pq.m**3, u_symbol='M')
+        molar = pq.UnitQuantity('M',  1000 * pq.mole/pq.m**3, u_symbol='M')
         for subtr in [1, 1.0]:
             q = 1*molar/(1000*pq.mole/pq.m**3)
             self.assertQuantityEqual((q - subtr).simplified, 0)

--- a/quantities/tests/test_umath.py
+++ b/quantities/tests/test_umath.py
@@ -163,6 +163,10 @@ class TestUmath(TestCase):
         self.assertQuantityEqual(np.exp(1*pq.dimensionless), np.e)
         self.assertRaises(ValueError, np.exp, 1*pq.m)
 
+    def test_exp2(self):
+        self.assertQuantityEqual(np.exp2(1*pq.dimensionless), 2.0)
+        self.assertRaises(ValueError, np.exp2, 1*pq.m)
+
     def test_log(self):
         self.assertQuantityEqual(np.log(1*pq.dimensionless), 0)
         self.assertRaises(ValueError, np.log, 1*pq.m)

--- a/quantities/tests/test_uncertainty.py
+++ b/quantities/tests/test_uncertainty.py
@@ -40,6 +40,8 @@ class TestUncertainty(TestCase):
         self.assertTrue(in_meters.dtype == seventyish_km.dtype)
         seventyish_km_rescaled_idempotent = seventyish_km.rescale(pq.km)
         self.assertTrue(seventyish_km_rescaled_idempotent.dtype == np.float32)
+        self.assertQuantityEqual(seventyish_km + in_meters, 2*seventy_km)
+
 
     def test_set_uncertainty(self):
         a = UncertainQuantity([1, 2], 'm', [.1, .2])

--- a/quantities/tests/test_uncertainty.py
+++ b/quantities/tests/test_uncertainty.py
@@ -1,4 +1,5 @@
 from .. import units as pq
+from ..quantity import Quantity
 from ..uncertainquantity import UncertainQuantity
 from .common import TestCase
 import numpy as np
@@ -30,6 +31,13 @@ class TestUncertainty(TestCase):
             a.rescale('ft').uncertainty,
             [0.32808399, 0.32808399, 0.32808399]*pq.ft
             )
+
+        seventy_km = Quantity(70, pq.km, dtype=np.float32)
+        seven_km = Quantity(7, pq.km, dtype=np.float32)
+        seventyish_km = UncertainQuantity(seventy_km, pq.km, seven_km, dtype=np.float32)
+        self.assertTrue(seventyish_km.dtype == np.float32)
+        in_meters = seventyish_km.rescale(pq.m)
+        self.assertTrue(in_meters.dtype == seventyish_km.dtype)
 
     def test_set_uncertainty(self):
         a = UncertainQuantity([1, 2], 'm', [.1, .2])

--- a/quantities/tests/test_uncertainty.py
+++ b/quantities/tests/test_uncertainty.py
@@ -38,6 +38,8 @@ class TestUncertainty(TestCase):
         self.assertTrue(seventyish_km.dtype == np.float32)
         in_meters = seventyish_km.rescale(pq.m)
         self.assertTrue(in_meters.dtype == seventyish_km.dtype)
+        seventyish_km_rescaled_idempotent = seventyish_km.rescale(pq.km)
+        self.assertTrue(seventyish_km_rescaled_idempotent.dtype == np.float32)
 
     def test_set_uncertainty(self):
         a = UncertainQuantity([1, 2], 'm', [.1, .2])

--- a/quantities/uncertainquantity.py
+++ b/quantities/uncertainquantity.py
@@ -64,10 +64,10 @@ class UncertainQuantity(Quantity):
         return self.uncertainty.magnitude/self.magnitude
 
     @with_doc(Quantity.rescale, use_header=False)
-    def rescale(self, units):
+    def rescale(self, units, dtype=None):
         cls = UncertainQuantity
-        ret = super(cls, self).rescale(units).view(cls)
-        ret.uncertainty = self.uncertainty.rescale(units)
+        ret = super(cls, self).rescale(units, dtype=dtype).view(cls)
+        ret.uncertainty = self.uncertainty.rescale(units, dtype=dtype)
         return ret
 
     def __array_finalize__(self, obj):
@@ -282,4 +282,3 @@ class UncertainQuantity(Quantity):
         reconstruct, reconstruct_args, state = super().__reduce__()
         state = state + (self._uncertainty,)
         return reconstruct, reconstruct_args, state
-


### PR DESCRIPTION
There are also some lines in `def astype` which look suspicious, (dtype is not propagated), but I have yet to come up with a small test for those. But I think this changeset is sensible on its own.