### PR TITLE
Switch `np` aliases which will be removed in NumPy 2.0

### DIFF
--- a/quantities/quantity.py
+++ b/quantities/quantity.py
@@ -604,8 +604,8 @@ class Quantity(np.ndarray):
         if min is None and max is None:
             raise ValueError("at least one of min or max must be set")
         else:
-            if min is None: min = Quantity(-np.Inf, self._dimensionality)
-            if max is None: max = Quantity(np.Inf, self._dimensionality)
+            if min is None: min = Quantity(-np.inf, self._dimensionality)
+            if max is None: max = Quantity(np.inf, self._dimensionality)
 
         if self.dimensionality and not \
                 (isinstance(min, Quantity) and isinstance(max, Quantity)):

--- a/quantities/tests/test_umath.py
+++ b/quantities/tests/test_umath.py
@@ -17,7 +17,7 @@ class TestUmath(TestCase):
         self.assertQuantityEqual(np.sum(self.q), 10 * pq.J)
 
     def test_nansum(self):
-        c = [1,2,3, np.NaN] * pq.m
+        c = [1,2,3, np.nan] * pq.m
         self.assertQuantityEqual(np.nansum(c), 6 * pq.m)
 
     def test_cumprod(self):

--- a/quantities/tests/test_umath.py
+++ b/quantities/tests/test_umath.py
@@ -114,19 +114,19 @@ class TestUmath(TestCase):
             [0, 0, 0, 10] * pq.J
             )
 
-    def test_round_(self):
+    def test_round(self):
         self.assertQuantityEqual(
-            np.round_([.5, 1.5, 2.5, 3.5, 4.5] * pq.J),
+            np.round([.5, 1.5, 2.5, 3.5, 4.5] * pq.J),
             [0., 2., 2., 4., 4.] * pq.J
             )
 
         self.assertQuantityEqual(
-            np.round_([1,2,3,11] * pq.J, decimals=1),
+            np.round([1,2,3,11] * pq.J, decimals=1),
             [1, 2, 3, 11] * pq.J
             )
 
         self.assertQuantityEqual(
-            np.round_([1,2,3,11] * pq.J, decimals=-1),
+            np.round([1,2,3,11] * pq.J, decimals=-1),
             [0, 0, 0, 10] * pq.J
             )
 


### PR DESCRIPTION
Also `np.trapz` will be deprecated, and the recommendation is to switch to using a scipy function instead. I can delete trapz in this PR if you want or just leave it alone until it becomes a hard error. 