### PR TITLE
Update CI test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11" ]
         numpy-version: [ "1.20", "1.21", "1.22", "1.23", "1.24", "1.25", "1.26" ]
         exclude:
           - python-version: "3.8"
@@ -29,6 +29,10 @@ jobs:
             os: ubuntu-latest
           - python-version: "3.11"
             numpy-version: "1.21"
+            os: ubuntu-latest
+        include:
+          - python-version: "3.12"
+            numpy-version: "1.26"
             os: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -56,7 +60,6 @@ jobs:
         run: |
           python -m pip install -U pip
           python -m pip install -U setuptools
-          python -m pip install -U six  # needed by setuptools
           python -m pip install -U wheel
           python -m pip install -U pytest
           python -m pip install "numpy==${{ matrix.numpy-version }}"
@@ -76,13 +79,17 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11" ]
         numpy-version: [ "1.22", "1.23", "1.24", "1.25", "1.26" ]
         exclude:
           - python-version: "3.8"
             numpy-version: "1.25"
             os: ubuntu-latest
           - python-version: "3.8"
+            numpy-version: "1.26"
+            os: ubuntu-latest
+        include:
+          - python-version: "3.12"
             numpy-version: "1.26"
             os: ubuntu-latest
     steps:
@@ -111,7 +118,6 @@ jobs:
         run: |
           python -m pip install -U pip
           python -m pip install -U setuptools
-          python -m pip install -U six  # needed by setuptools
           python -m pip install -U wheel
           python -m pip install "numpy==${{ matrix.numpy-version }}"
           python -m pip install -U mypy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,7 @@ jobs:
         run: |
           python -m pip install -U pip
           python -m pip install -U setuptools
+          python -m pip install -U six  # needed by setuptools
           python -m pip install -U wheel
           python -m pip install -U pytest
           python -m pip install "numpy==${{ matrix.numpy-version }}"
@@ -110,6 +111,7 @@ jobs:
         run: |
           python -m pip install -U pip
           python -m pip install -U setuptools
+          python -m pip install -U six  # needed by setuptools
           python -m pip install -U wheel
           python -m pip install "numpy==${{ matrix.numpy-version }}"
           python -m pip install -U mypy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,12 @@ jobs:
         python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
         numpy-version: [ "1.20", "1.21", "1.22", "1.23", "1.24", "1.25", "1.26" ]
         exclude:
+          - python-version: "3.8"
+            numpy-version: "1.25"
+            os: ubuntu-latest
+          - python-version: "3.8"
+            numpy-version: "1.26"
+            os: ubuntu-latest
           - python-version: "3.10"
             numpy-version: "1.20"
             os: ubuntu-latest
@@ -49,6 +55,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install -U pip
+          python -m pip install -U setuptools
           python -m pip install -U wheel
           python -m pip install -U pytest
           python -m pip install "numpy==${{ matrix.numpy-version }}"
@@ -70,6 +77,13 @@ jobs:
         os: [ ubuntu-latest ]
         python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
         numpy-version: [ "1.22", "1.23", "1.24", "1.25", "1.26" ]
+        exclude:
+          - python-version: "3.8"
+            numpy-version: "1.25"
+            os: ubuntu-latest
+          - python-version: "3.8"
+            numpy-version: "1.26"
+            os: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 
@@ -95,6 +109,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install -U pip
+          python -m pip install -U setuptools
           python -m pip install -U wheel
           python -m pip install "numpy==${{ matrix.numpy-version }}"
           python -m pip install -U mypy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,17 +12,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ "3.8", "3.9", "3.10", "3.11" ]
-        numpy-version: [ "1.19", "1.20", "1.21", "1.22", "1.23", "1.24" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        numpy-version: [ "1.20", "1.21", "1.22", "1.23", "1.24", "1.25", "1.26" ]
         exclude:
           - python-version: "3.10"
-            numpy-version: "1.19"
-            os: ubuntu-latest
-          - python-version: "3.10"
             numpy-version: "1.20"
-            os: ubuntu-latest
-          - python-version: "3.11"
-            numpy-version: "1.19"
             os: ubuntu-latest
           - python-version: "3.11"
             numpy-version: "1.20"
@@ -74,8 +68,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ "3.8", "3.9", "3.10", "3.11" ]
-        numpy-version: [ "1.22", "1.23", "1.24" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        numpy-version: [ "1.22", "1.23", "1.24", "1.25", "1.26" ]
     steps:
       - uses: actions/checkout@v2
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
   "Topic :: Scientific/Engineering"
 ]
 dependencies = [
-  "numpy>=1.19"
+  "numpy>=1.20"
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Add Python 3.12, NumPy 1.25 and 1.26, remove Numpy 1.19

(reminder that we follow [NEP29](https://numpy.org/neps/nep-0029-deprecation_policy.html) plus one year)