### PR TITLE
Add support for NumPy 2.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,9 @@ jobs:
           - python-version: "3.12"
             numpy-version: "1.26"
             os: ubuntu-latest
+          - python-version: "3.12"
+            numpy-version: "2.0"
+            os: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 

--- a/quantities/__init__.py
+++ b/quantities/__init__.py
@@ -265,6 +265,8 @@ units, they should still conform to valid python expressions.
 
 """
 
+class QuantitiesDeprecationWarning(DeprecationWarning):
+    pass
 
 from ._version import __version__
 

--- a/quantities/dimensionality.py
+++ b/quantities/dimensionality.py
@@ -9,6 +9,8 @@ from . import markup
 from .registry import unit_registry
 from .decorators import memoize
 
+_np_version = tuple(map(int, np.__version__.split('.')))
+
 def assert_isinstance(obj, types):
     try:
         assert isinstance(obj, types)
@@ -329,10 +331,11 @@ p_dict[np.ceil] = _d_copy
 
 def _d_clip(a1, a2, a3, q):
     return q.dimensionality
-try:
+
+if _np_version < (2, 0, 0):
     p_dict[np.core.umath.clip] = _d_clip
-except AttributeError:
-    pass # For compatibility with Numpy < 1.17 when clip wasn't a ufunc yet
+else:
+    p_dict[np.clip] = _d_clip
 
 def _d_sqrt(q1, out=None):
     return q1._dimensionality**0.5

--- a/quantities/tests/test_arithmetic.py
+++ b/quantities/tests/test_arithmetic.py
@@ -48,32 +48,9 @@ def check(f, *args, **kwargs):
     return (new, )
 
 
-class iter_dtypes:
-
-    def __init__(self):
-        self._i = 1
-        self._typeDict = np.sctypeDict.copy()
-        self._typeDict[17] = int
-        self._typeDict[18] = long
-        self._typeDict[19] = float
-        self._typeDict[20] = complex
-
-    def __iter__(self):
-        return self
-
-    def __next__(self):
-        if self._i > 20:
-            raise StopIteration
-
-        i = self._i
-        self._i += 1
-        return self._typeDict[i]
-
-    def next(self):
-        return self.__next__()
-
 def get_dtypes():
-    return list(iter_dtypes())
+    numeric_dtypes = 'iufc'  # https://numpy.org/doc/stable/reference/generated/numpy.dtype.kind.html
+    return [v for v in np.sctypeDict.values() if np.dtype(v).kind in numeric_dtypes] + [int, long, float, complex]
 
 
 class iter_types:

--- a/quantities/tests/test_methods.py
+++ b/quantities/tests/test_methods.py
@@ -1,4 +1,5 @@
-from .. import units as pq
+import warnings
+from .. import QuantitiesDeprecationWarning, units as pq
 from .common import TestCase
 import numpy as np
 
@@ -119,7 +120,10 @@ class TestQuantityMethods(TestCase):
         )
         if isinstance(result, Quantity):
             # deliberately using an incompatible unit
-            out = Quantity(np.empty_like(result.magnitude), pq.s, copy=False)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", category=QuantitiesDeprecationWarning)
+                out = Quantity(np.empty_like(result.magnitude), pq.s, copy=False)
+            # we can drop 'copy=False' above once the deprecation of the arg has expired.
         else:
             out = np.empty_like(result)
         ret = getattr(q.copy(), name)(*args, out=out, **kw)

--- a/quantities/tests/test_umath.py
+++ b/quantities/tests/test_umath.py
@@ -3,6 +3,8 @@ import numpy as np
 from .. import units as pq
 from .common import TestCase, unittest
 
+_np_version = tuple(map(int, np.__version__.split('.')))
+
 
 class TestUmath(TestCase):
 
@@ -54,7 +56,13 @@ class TestUmath(TestCase):
         self.assertQuantityEqual(np.cross(a,b), [-15,-2,39]*pq.kPa*pq.m**2)
 
     def test_trapz(self):
-        self.assertQuantityEqual(np.trapz(self.q, dx = 1*pq.m), 7.5 * pq.J*pq.m)
+        # np.trapz is deprecated, np.trapezoid is recommend
+        if _np_version < (2, 0, 0):
+            self.assertQuantityEqual(np.trapz(self.q, dx = 1*pq.m), 7.5 * pq.J*pq.m)
+
+    def test_trapezoid(self):
+        if _np_version >= (2, 0, 0):
+            self.assertQuantityEqual(np.trapezoid(self.q, dx = 1*pq.m), 7.5 * pq.J*pq.m)
 
     def test_sinh(self):
         q = [1, 2, 3, 4, 6] * pq.radian

--- a/quantities/uncertainquantity.py
+++ b/quantities/uncertainquantity.py
@@ -118,7 +118,7 @@ class UncertainQuantity(Quantity):
             ru = (sru**2+oru**2)**0.5
             u = res.view(Quantity) * ru
         except AttributeError:
-            other = np.array(other, copy=False, subok=True)
+            other = np.asanyarray(other)
             u = (self.uncertainty**2*other**2)**0.5
 
         res._uncertainty = u
@@ -140,7 +140,7 @@ class UncertainQuantity(Quantity):
             ru = (sru**2+oru**2)**0.5
             u = res.view(Quantity) * ru
         except AttributeError:
-            other = np.array(other, copy=False, subok=True)
+            other = np.asanyarray(other)
             u = (self.uncertainty**2/other**2)**0.5
 
         res._uncertainty = u

--- a/quantities/uncertainquantity.py
+++ b/quantities/uncertainquantity.py
@@ -2,8 +2,9 @@
 """
 
 import numpy as np
+import warnings
 
-from . import markup
+from . import markup, QuantitiesDeprecationWarning
 from .quantity import Quantity, scale_other_units
 from .registry import unit_registry
 from .decorators import with_doc
@@ -13,15 +14,20 @@ class UncertainQuantity(Quantity):
     # TODO: what is an appropriate value?
     __array_priority__ = 22
 
-    def __new__(cls, data, units='', uncertainty=None, dtype='d', copy=True):
-        ret = Quantity.__new__(cls, data, units, dtype, copy)
+    def __new__(cls, data, units='', uncertainty=None, dtype='d', copy=None):
+        if copy is not None:
+            warnings.warn(("The 'copy' argument in UncertainQuantity is deprecated and will be removed in the future. "
+                           "The argument has no effect since quantities-0.16.0 (to aid numpy-2.0 support)."),
+                           QuantitiesDeprecationWarning, stacklevel=2)
+        ret = Quantity.__new__(cls, data, units, dtype)
         # _uncertainty initialized to be dimensionless by __array_finalize__:
         ret._uncertainty._dimensionality = ret._dimensionality
 
         if uncertainty is not None:
             ret.uncertainty = Quantity(uncertainty, ret._dimensionality)
         elif isinstance(data, UncertainQuantity):
-            if copy or ret._dimensionality != uncertainty._dimensionality:
+            is_copy = id(data) == id(ret)
+            if is_copy or ret._dimensionality != uncertainty._dimensionality:
                 uncertainty = data.uncertainty.rescale(ret.units)
             ret.uncertainty = uncertainty
 
@@ -50,7 +56,7 @@ class UncertainQuantity(Quantity):
     @uncertainty.setter
     def uncertainty(self, uncertainty):
         if not isinstance(uncertainty, Quantity):
-            uncertainty = Quantity(uncertainty, copy=False)
+            uncertainty = Quantity(uncertainty)
         try:
             assert self.shape == uncertainty.shape
         except AssertionError:
@@ -78,7 +84,6 @@ class UncertainQuantity(Quantity):
             Quantity(
                 np.zeros(self.shape, self.dtype),
                 self._dimensionality,
-                copy=False
             )
         )
 
@@ -87,7 +92,7 @@ class UncertainQuantity(Quantity):
     def __add__(self, other):
         res = super().__add__(other)
         u = (self.uncertainty**2+other.uncertainty**2)**0.5
-        return UncertainQuantity(res, uncertainty=u, copy=False)
+        return UncertainQuantity(res, uncertainty=u)
 
     @with_doc(Quantity.__radd__, use_header=False)
     @scale_other_units
@@ -99,13 +104,13 @@ class UncertainQuantity(Quantity):
     def __sub__(self, other):
         res = super().__sub__(other)
         u = (self.uncertainty**2+other.uncertainty**2)**0.5
-        return UncertainQuantity(res, uncertainty=u, copy=False)
+        return UncertainQuantity(res, uncertainty=u)
 
     @with_doc(Quantity.__rsub__, use_header=False)
     @scale_other_units
     def __rsub__(self, other):
         if not isinstance(other, UncertainQuantity):
-            other = UncertainQuantity(other, copy=False)
+            other = UncertainQuantity(other)
 
         return UncertainQuantity.__sub__(other, self)
 
@@ -150,7 +155,7 @@ class UncertainQuantity(Quantity):
     def __rtruediv__(self, other):
         temp = UncertainQuantity(
             1/self.magnitude, self.dimensionality**-1,
-            self.relative_uncertainty/self.magnitude, copy=False
+            self.relative_uncertainty/self.magnitude
         )
         return other * temp
 
@@ -165,8 +170,7 @@ class UncertainQuantity(Quantity):
         return UncertainQuantity(
             self.magnitude[key],
             self._dimensionality,
-            self.uncertainty[key],
-            copy=False
+            self.uncertainty[key]
         )
 
     @with_doc(Quantity.__repr__, use_header=False)
@@ -198,8 +202,7 @@ class UncertainQuantity(Quantity):
         return UncertainQuantity(
             self.magnitude.sum(axis, dtype, out),
             self.dimensionality,
-            (np.sum(self.uncertainty.magnitude**2, axis))**0.5,
-            copy=False
+            (np.sum(self.uncertainty.magnitude**2, axis))**0.5
         )
 
     @with_doc(np.nansum)
@@ -207,8 +210,7 @@ class UncertainQuantity(Quantity):
         return UncertainQuantity(
             np.nansum(self.magnitude, axis, dtype, out),
             self.dimensionality,
-            (np.nansum(self.uncertainty.magnitude**2, axis))**0.5,
-            copy=False
+            (np.nansum(self.uncertainty.magnitude**2, axis))**0.5
         )
 
     @with_doc(np.ndarray.mean)
@@ -216,8 +218,8 @@ class UncertainQuantity(Quantity):
         return UncertainQuantity(
             self.magnitude.mean(axis, dtype, out),
             self.dimensionality,
-            ((1.0/np.size(self,axis))**2 * np.sum(self.uncertainty.magnitude**2, axis))**0.5,
-            copy=False)
+            ((1.0/np.size(self,axis))**2 * np.sum(self.uncertainty.magnitude**2, axis))**0.5
+        )
 
     @with_doc(np.nanmean)
     def nanmean(self, axis=None, dtype=None, out=None):
@@ -225,8 +227,8 @@ class UncertainQuantity(Quantity):
         return UncertainQuantity(
             np.nanmean(self.magnitude, axis, dtype, out),
             self.dimensionality,
-            ((1.0/size)**2 * np.nansum(np.nan_to_num(self.uncertainty.magnitude)**2, axis))**0.5,
-            copy=False)
+            ((1.0/size)**2 * np.nansum(np.nan_to_num(self.uncertainty.magnitude)**2, axis))**0.5
+        )
 
     @with_doc(np.sqrt)
     def sqrt(self, out=None):


### PR DESCRIPTION
Seems like NumPy 2.0 broke some behavior which quantities relied on. This PR allows the test suite to pass for me locally. I have not addressed any deprecation warnings that are new in numpy 2.0. I'm thinking that we can fix those in a subsequent PR.

Let me know what you think.