### PR TITLE
Prevent arbitrary code eval

### DIFF
--- a/quantities/registry.py
+++ b/quantities/registry.py
@@ -21,6 +21,8 @@ class UnitRegistry:
             all_builtins = dir(builtins)
             # because we have kilobytes, other bytes we have to remove bytes
             all_builtins.remove("bytes")
+            # have to deal with octet as well
+            all_builtins.remove("oct")
             for builtin in all_builtins:
                 if builtin in string:
                     raise RuntimeError(f"String parsing error for {string}. Enter a string accepted by quantities")

--- a/quantities/registry.py
+++ b/quantities/registry.py
@@ -20,7 +20,7 @@ class UnitRegistry:
             # easy hack to prevent arbitrary evaluation of code
             all_builtins = dir(builtins)
             # because we have kilobytes, other bytes we have to remove bytes
-            all_builtins = all_builtins.remove("bytes")
+            all_builtins.remove("bytes")
             for builtin in all_builtins:
                 if builtin in string:
                     raise RuntimeError(f"String parsing error for {string}. Enter a string accepted by quantities")

--- a/quantities/registry.py
+++ b/quantities/registry.py
@@ -1,8 +1,8 @@
 """
 """
 
-import copy
 import re
+import builtins
 
 
 class UnitRegistry:
@@ -16,6 +16,13 @@ class UnitRegistry:
             self.__context = {}
 
         def __getitem__(self, string):
+            
+            # easy hack to prevent arbitrary evaluation of code
+            all_builtins = dir(builtins)
+            for builtin in all_builtins:
+                if builtin in string:
+                    raise RuntimeError(f"String parsing error for {string}. Enter a string accepted by quantities")
+
             try:
                 return eval(string, self.__context)
             except NameError:

--- a/quantities/registry.py
+++ b/quantities/registry.py
@@ -19,6 +19,8 @@ class UnitRegistry:
             
             # easy hack to prevent arbitrary evaluation of code
             all_builtins = dir(builtins)
+            # because we have kilobytes, other bytes we have to remove bytes
+            all_builtins = all_builtins.remove("bytes")
             for builtin in all_builtins:
                 if builtin in string:
                     raise RuntimeError(f"String parsing error for {string}. Enter a string accepted by quantities")


### PR DESCRIPTION
Fixes #221.

@codingchipmunk feel free to look at this. It's a bit of a hammer, but this blocks arbitrary eval of any python built-ins.

@apdavison, I would say this type of security would be nice to have even before the next release.