### PR TITLE
Fix numpy version string parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist
 .*cache/
 _version.py
 MANIFEST
+.venv

--- a/quantities/dimensionality.py
+++ b/quantities/dimensionality.py
@@ -9,7 +9,8 @@ from . import markup
 from .registry import unit_registry
 from .decorators import memoize
 
-_np_version = tuple(map(int, np.__version__.split('.')))
+_np_version = tuple(map(int, np.__version__.split(".dev")[0].split(".")))
+
 
 def assert_isinstance(obj, types):
     try:

--- a/quantities/quantity.py
+++ b/quantities/quantity.py
@@ -291,7 +291,7 @@ class Quantity(np.ndarray):
         return res
 
     def __array_wrap__(self, obj, context=None, return_scalar=False):
-        _np_version = tuple(map(int, np.__version__.split('.')))
+        _np_version = tuple(map(int, np.__version__.split(".dev")[0].split(".")))
         # For NumPy < 2.0 we do old behavior
         if _np_version < (2, 0, 0):
             if not isinstance(obj, Quantity):

--- a/quantities/tests/test_umath.py
+++ b/quantities/tests/test_umath.py
@@ -3,7 +3,7 @@ import numpy as np
 from .. import units as pq
 from .common import TestCase, unittest
 
-_np_version = tuple(map(int, np.__version__.split('.')))
+_np_version = tuple(map(int, np.__version__.split(".dev")[0].split(".")))
 
 
 class TestUmath(TestCase):


### PR DESCRIPTION
The parsing added in the latest release does not work with development version and breaks MNE workflow here: https://github.com/mne-tools/mne-python/pull/12815

https://github.com/mne-tools/mne-python/actions/runs/10577439355/job/29305416424#step:17:67