### PR TITLE
Fix registry for `min` in buitlins

### DIFF
--- a/quantities/registry.py
+++ b/quantities/registry.py
@@ -27,7 +27,7 @@ class UnitRegistry:
             all_builtins.remove("min")
             for builtin in all_builtins:
                 if builtin in string:
-                    raise RuntimeError(f"String parsing error for {string}. Enter a string accepted by quantities")
+                    raise RuntimeError(f"String parsing error for `{string}`. Enter a string accepted by quantities")
 
             try:
                 return eval(string, self.__context)

--- a/quantities/registry.py
+++ b/quantities/registry.py
@@ -23,6 +23,8 @@ class UnitRegistry:
             all_builtins.remove("bytes")
             # have to deal with octet as well
             all_builtins.remove("oct")
+            # have to remove min which is short for minute
+            all_builtins.remove("min")
             for builtin in all_builtins:
                 if builtin in string:
                     raise RuntimeError(f"String parsing error for {string}. Enter a string accepted by quantities")

--- a/quantities/tests/test_arithmetic.py
+++ b/quantities/tests/test_arithmetic.py
@@ -226,6 +226,12 @@ class TestDTypes(TestCase):
             [1, 2, 3]*pq.hp + [1, 2, 3]*pq.hp,
             [2, 4, 6]*pq.hp
         )
+        # add in test with 'min' since this caused issues
+        # see https://github.com/python-quantities/python-quantities/issues/243
+        self.assertQuantityEqual(
+            Quantity(1, 'min') + Quantity(1, 'min'),
+            2*pq.min
+        )
 
         self.assertRaises(ValueError, op.add, pq.kPa, pq.lb)
         self.assertRaises(ValueError, op.add, pq.kPa, 10)

--- a/quantities/tests/test_conversion.py
+++ b/quantities/tests/test_conversion.py
@@ -97,6 +97,10 @@ class TestDefaultUnits(TestCase):
         self.assertQuantityEqual(pq.kg.simplified, 1000*pq.g)
         self.assertQuantityEqual(pq.m.simplified, 1000*pq.mm)
 
+        # test a time default as well as mass and weight
+        pq.set_default_units('SI')
+        self.assertQuantityEqual(pq.min.simplified, 60*pq.sec)
+
 class TestUnitInformation(TestCase):
 
     def test_si(self):

--- a/quantities/units/time.py
+++ b/quantities/units/time.py
@@ -64,7 +64,7 @@ min = minute = UnitTime(
     60*s,
     symbol='min',
     aliases=['minutes']
-)
+) # min is function in python
 h = hr = hour = UnitTime(
     'hour',
     60*min,


### PR DESCRIPTION
@apdavison while working on updating the min the Neo ci discovered that `min` is used for minute. So I need to remove that from the builtins. There was no test for this in quantities ci. 