### PR TITLE
Added "plain" property to quantity

### DIFF
--- a/quantities/quantity.py
+++ b/quantities/quantity.py
@@ -474,7 +474,7 @@ class Quantity(np.ndarray):
 
     @with_doc(np.ndarray.__gt__)
     def __gt__(self, other):
-        return (self - other).magnitude >= 0
+        return (self - other).magnitude > 0
 
     #I don't think this implementation is particularly efficient,
     #perhaps there is something better

--- a/quantities/quantity.py
+++ b/quantities/quantity.py
@@ -99,16 +99,6 @@ def protected_power(f):
         return f(self, other, *args)
     return g
 
-def wrap_comparison(f):
-    @wraps(f)
-    def g(self, other):
-        if isinstance(other, Quantity):
-            if other._dimensionality != self._dimensionality:
-                other = other.rescale(self._dimensionality)
-            other = other.magnitude
-        return f(self, other)
-    return g
-
 
 class Quantity(np.ndarray):
 
@@ -440,14 +430,12 @@ class Quantity(np.ndarray):
         self.magnitude[key] = value
 
     @with_doc(np.ndarray.__lt__)
-    @wrap_comparison
     def __lt__(self, other):
-        return self.magnitude < other
+        return (self - other).magnitude < 0
 
     @with_doc(np.ndarray.__le__)
-    @wrap_comparison
     def __le__(self, other):
-        return self.magnitude <= other
+        return (self - other).magnitude <= 0
 
     @with_doc(np.ndarray.__eq__)
     def __eq__(self, other):
@@ -455,8 +443,15 @@ class Quantity(np.ndarray):
             try:
                 other = other.rescale(self._dimensionality).magnitude
             except ValueError:
-                return np.zeros(self.shape, '?')
-        return self.magnitude == other
+                return np.logical_and(self.magnitude != other.magnitude, False)
+            return self.magnitude == other
+        else:
+            try:
+                pln = self.plain
+            except ValueError:
+                return np.logical_and(self.magnitude != other, False)
+            return pln == other
+
 
     @with_doc(np.ndarray.__ne__)
     def __ne__(self, other):
@@ -464,18 +459,22 @@ class Quantity(np.ndarray):
             try:
                 other = other.rescale(self._dimensionality).magnitude
             except ValueError:
-                return np.ones(self.shape, '?')
-        return self.magnitude != other
-
+                return np.logical_or(self.magnitude != other.magnitude, True)
+            return self.magnitude != other
+        else:
+            try:
+                pln = self.plain
+            except ValueError:
+                return np.logical_or(self.magnitude != other, True)
+            return pln != other
+        
     @with_doc(np.ndarray.__ge__)
-    @wrap_comparison
     def __ge__(self, other):
-        return self.magnitude >= other
+        return (self - other).magnitude >= 0
 
     @with_doc(np.ndarray.__gt__)
-    @wrap_comparison
     def __gt__(self, other):
-        return self.magnitude > other
+        return (self - other).magnitude >= 0
 
     #I don't think this implementation is particularly efficient,
     #perhaps there is something better

--- a/quantities/quantity.py
+++ b/quantities/quantity.py
@@ -250,6 +250,21 @@ class Quantity(np.ndarray):
         raise Exception("Preferred units for '%s' (or equivalent) not specified in "
                         "quantites.quantity.PREFERRED." % self.dimensionality)
 
+    @property
+    def plain(self):
+        """
+        Return a copy of the quantity as a plain number provided that the quantity
+        is dimensionless. For example:
+        ```
+        import quantities as pq
+        t = 2 * pq.ms
+        f = 3 * pq.MHz
+        n = (t*f).plain # n will be 6000
+        ```
+        If the quantity is not dimensionless, a conversion error is raised.
+        """
+        return self.rescale(unit_registry['dimensionless']).magnitude
+
     @with_doc(np.ndarray.astype)
     def astype(self, dtype=None, **kwargs):
         '''Scalars are returned as scalar Quantity arrays.'''


### PR DESCRIPTION
The new "plain" property returns a copy of the quantity as a plain number provided that the quantity is dimensionless. For example:

    import quantities as pq
    t = 2 * pq.ms
    f = 3 * pq.MHz
    n = (t*f).plain # n will be 6000

If the quantity is not dimensionless, a conversion error is raised.