### PR TITLE
Improved behavior of comparison between quantities

### DIFF
--- a/quantities/quantity.py
+++ b/quantities/quantity.py
@@ -432,9 +432,9 @@ class Quantity(np.ndarray):
             return self.magnitude == other
         else:
             try:
-                pln = self.plain
+                pln = self.rescale(unit_registry['dimensionless']).magnitude
             except ValueError:
-                return np.logical_and(self.magnitude != other, False)
+                return np.logical_and(self.magnitude == other, False)
             return pln == other
 
 
@@ -448,7 +448,7 @@ class Quantity(np.ndarray):
             return self.magnitude != other
         else:
             try:
-                pln = self.plain
+                pln = self.rescale(unit_registry['dimensionless']).magnitude
             except ValueError:
                 return np.logical_or(self.magnitude != other, True)
             return pln != other

--- a/quantities/quantity.py
+++ b/quantities/quantity.py
@@ -459,7 +459,7 @@ class Quantity(np.ndarray):
 
     @with_doc(np.ndarray.__gt__)
     def __gt__(self, other):
-        return (self - other).magnitude >= 0
+        return (self - other).magnitude > 0
 
     #I don't think this implementation is particularly efficient,
     #perhaps there is something better

--- a/quantities/quantity.py
+++ b/quantities/quantity.py
@@ -99,16 +99,6 @@ def protected_power(f):
         return f(self, other, *args)
     return g
 
-def wrap_comparison(f):
-    @wraps(f)
-    def g(self, other):
-        if isinstance(other, Quantity):
-            if other._dimensionality != self._dimensionality:
-                other = other.rescale(self._dimensionality)
-            other = other.magnitude
-        return f(self, other)
-    return g
-
 
 class Quantity(np.ndarray):
 
@@ -425,14 +415,12 @@ class Quantity(np.ndarray):
         self.magnitude[key] = value
 
     @with_doc(np.ndarray.__lt__)
-    @wrap_comparison
     def __lt__(self, other):
-        return self.magnitude < other
+        return (self - other).magnitude < 0
 
     @with_doc(np.ndarray.__le__)
-    @wrap_comparison
     def __le__(self, other):
-        return self.magnitude <= other
+        return (self - other).magnitude <= 0
 
     @with_doc(np.ndarray.__eq__)
     def __eq__(self, other):
@@ -440,8 +428,15 @@ class Quantity(np.ndarray):
             try:
                 other = other.rescale(self._dimensionality).magnitude
             except ValueError:
-                return np.zeros(self.shape, '?')
-        return self.magnitude == other
+                return np.logical_and(self.magnitude != other.magnitude, False)
+            return self.magnitude == other
+        else:
+            try:
+                pln = self.plain
+            except ValueError:
+                return np.logical_and(self.magnitude != other, False)
+            return pln == other
+
 
     @with_doc(np.ndarray.__ne__)
     def __ne__(self, other):
@@ -449,18 +444,22 @@ class Quantity(np.ndarray):
             try:
                 other = other.rescale(self._dimensionality).magnitude
             except ValueError:
-                return np.ones(self.shape, '?')
-        return self.magnitude != other
-
+                return np.logical_or(self.magnitude != other.magnitude, True)
+            return self.magnitude != other
+        else:
+            try:
+                pln = self.plain
+            except ValueError:
+                return np.logical_or(self.magnitude != other, True)
+            return pln != other
+        
     @with_doc(np.ndarray.__ge__)
-    @wrap_comparison
     def __ge__(self, other):
-        return self.magnitude >= other
+        return (self - other).magnitude >= 0
 
     @with_doc(np.ndarray.__gt__)
-    @wrap_comparison
     def __gt__(self, other):
-        return self.magnitude > other
+        return (self - other).magnitude >= 0
 
     #I don't think this implementation is particularly efficient,
     #perhaps there is something better

--- a/quantities/tests/test_comparison.py
+++ b/quantities/tests/test_comparison.py
@@ -64,7 +64,7 @@ class TestComparison(TestCase):
         )
         self.assertQuantityEqual(
             [1, 2, 3, 4]*pq.J == [1, 22, 3, 44],
-            [1, 0, 1, 0]
+            [0, 0, 0, 0]
         )
 
     def test_array_inequality(self):
@@ -78,7 +78,7 @@ class TestComparison(TestCase):
         )
         self.assertQuantityEqual(
             [1, 2, 3, 4]*pq.J != [1, 22, 3, 44],
-            [0, 1, 0, 1]
+            [1, 1, 1, 1]
         )
 
     def test_quantity_less_than(self):
@@ -90,9 +90,11 @@ class TestComparison(TestCase):
             [50, 100, 150]*pq.cm < [1, 1, 1]*pq.m,
             [1, 0, 0]
         )
-        self.assertQuantityEqual(
-            [1, 2, 33]*pq.J < [1, 22, 3],
-            [0, 1, 0]
+        self.assertRaises(
+            ValueError,
+            op.lt, 
+            [1, 2, 33]*pq.J,
+            [1, 22, 3],
         )
         self.assertRaises(
             ValueError,
@@ -110,9 +112,11 @@ class TestComparison(TestCase):
             [50, 100, 150]*pq.cm <= [1, 1, 1]*pq.m,
             [1, 1, 0]
         )
-        self.assertQuantityEqual(
-            [1, 2, 33]*pq.J <= [1, 22, 3],
-            [1, 1, 0]
+        self.assertRaises(
+            ValueError,
+            op.le,
+            [1, 2, 33]*pq.J,
+            [1, 22, 3],
         )
         self.assertRaises(
             ValueError,
@@ -130,9 +134,11 @@ class TestComparison(TestCase):
             [50, 100, 150]*pq.cm >= [1, 1, 1]*pq.m,
             [0, 1, 1]
         )
-        self.assertQuantityEqual(
-            [1, 2, 33]*pq.J >= [1, 22, 3],
-            [1, 0, 1]
+        self.assertRaises(
+            ValueError,
+            op.ge,
+            [1, 2, 33]*pq.J,
+            [1, 22, 3],
         )
         self.assertRaises(
             ValueError,
@@ -150,9 +156,11 @@ class TestComparison(TestCase):
             [50, 100, 150]*pq.cm > [1, 1, 1]*pq.m,
             [0, 0, 1]
         )
-        self.assertQuantityEqual(
-            [1, 2, 33]*pq.J > [1, 22, 3],
-            [0, 0, 1]
+        self.assertRaises(
+            ValueError,
+            op.gt,
+            [1, 2, 33]*pq.J,
+            [1, 22, 3],
         )
         self.assertRaises(
             ValueError,
@@ -160,3 +168,46 @@ class TestComparison(TestCase):
             [1, 2, 33]*pq.J,
             [1, 22, 3]*pq.kg,
         )
+
+    def test_quantity_more_raises(self):
+        self.assertRaises(ValueError, op.gt, pq.ms, 1)
+        self.assertRaises(ValueError, op.ge, pq.ms, 1)
+        self.assertRaises(ValueError, op.lt, pq.ms, 1)
+        self.assertRaises(ValueError, op.le, pq.ms, 1)
+
+    def test_quantity_more_equal(self):
+        self.assertEqual(pq.ms == 1, False)
+        self.assertEqual(pq.ms != 1, True)
+        self.assertEqual(pq.ms == .001 * pq.m, False)
+        self.assertEqual(pq.ms != .001 * pq.m, True)
+        self.assertEqual(pq.ms == .001 * pq.s, True)
+        self.assertEqual(pq.ms != .001 * pq.s, False)
+
+    def test_quantity_more_compare(self):
+        self.assertEqual(pq.ms * pq.Hz < 1, True)
+        self.assertEqual(pq.ms * pq.Hz <= 1, True)
+        self.assertEqual(pq.ms * pq.Hz > 1, False)
+        self.assertEqual(pq.ms * pq.Hz >= 1, False)
+        self.assertEqual(pq.ms * pq.Hz == 0.001, True)
+        self.assertEqual(pq.ms * pq.Hz != 0.001, False)
+        self.assertEqual(pq.ms * pq.Hz >= 0.001, True)
+        self.assertEqual(pq.ms * pq.Hz <= 0.001, True)
+
+        self.assertQuantityEqual([1, 2, 3, 4] * pq.ms * pq.Hz
+                                 == [0.001, 0.022, 0.003, 0.044],
+                                 [1, 0, 1, 0])
+        self.assertQuantityEqual([1, 2, 3, 4] * pq.ms * pq.Hz
+                                 != [0.001, 0.022, 0.003, 0.044],
+                                 [0, 1, 0, 1])
+        self.assertQuantityEqual([1, 2, 33] * pq.ms * pq.Hz
+                                 < [0.001, 0.020, 0.003],
+                                 [0, 1, 0])
+        self.assertQuantityEqual([1, 2, 33] * pq.ms * pq.Hz
+                                 <= [0.001, 0.020, 0.003],
+                                 [1, 1, 0])
+        self.assertQuantityEqual([1, 2, 33] * pq.ms * pq.Hz
+                                 >= [0.001, 0.020, 0.003],
+                                 [1, 0, 1])
+        self.assertQuantityEqual([1, 2, 33] * pq.ms * pq.Hz
+                                 > [0.001, 0.020, 0.003],
+                                 [0, 0, 1])        


### PR DESCRIPTION
For quantities A and B of unequal dimensionality, the `==` operator now returns an array of the same shape that numpy would return if A and B were different and filled with False.

In particular, if both A and B are scalar arrays, the result is a scalar False. Previously, a scalar array (`np.array(False)`) would be returned under these circumstances.
    
If A and B do not have compatible sizes, an exception is generated.
    
The `!=` operator behaves the same except that it fills the result with True values.
    
The other comparison operators now raise exceptions if a quantity that is not dimensionless is compared to a plain number. For effectively dimensionless quantities the comparison is now consistent. Previously, if

        n = pq.s * pq.kHz

then `n < 2` would return True but `n.simplified < 2` would return False. Now, both return False.
    
Comparison between incompatible quantities raises exceptions as before.

Closes #245 
