### PR TITLE
fix: deepcopy

### DIFF
--- a/quantities/quantity.py
+++ b/quantities/quantity.py
@@ -804,10 +804,6 @@ class Quantity(np.ndarray):
                 (self.__class__, np.ndarray, (0, ), 'b', ),
                 state)
 
-    def __deepcopy__(self, memo_dict):
-        # constructor copies by default
-        return Quantity(self.magnitude, self.dimensionality)
-
 
 def _reconstruct_quantity(subtype, baseclass, baseshape, basetype,):
     """Internal function that builds a new MaskedArray from the

--- a/quantities/tests/test_persistence.py
+++ b/quantities/tests/test_persistence.py
@@ -71,6 +71,15 @@ class TestPersistence(TestCase):
             y = copy.copy(x)
             self.assertQuantityEqual(x, y)
 
+    def test_deepcopy_quantity(self):
+        x = [1, 2, 3] * pq.m
+        y = copy.deepcopy(x)
+        self.assertQuantityEqual(x, y)
+
+        y[0] = 100 * pq.m
+        self.assertQuantityEqual(x, [1, 2, 3] * pq.m)
+
+
     def test_copy_uncertainquantity(self):
         for dtype in [float, object]:
             x = UncertainQuantity(20, 'm', 0.2).astype(dtype)


### PR DESCRIPTION
`quantities.Quantity.deepcopy` assumed that new objects copy the data per default. This is no longer true since the adaptation to numpy 2 (#235, commit: ed43021).