### PR TITLE
fix: np.ndarray.ptp (removed) -> np.ptp

### DIFF
--- a/quantities/quantity.py
+++ b/quantities/quantity.py
@@ -629,7 +629,7 @@ class Quantity(np.ndarray):
     def nanargmax(self,axis=None, out=None):
         return np.nanargmax(self.magnitude)
 
-    @with_doc(np.ndarray.ptp)
+    @with_doc(np.ptp)
     def ptp(self, axis=None, out=None):
         ret = np.ptp(self.magnitude, axis, None if out is None else out.magnitude)
         dim = self.dimensionality


### PR DESCRIPTION
over at MNE-Python, we're hitting a CI failure that traces back to quantities. TL;DR: you reference `np.ndarray.ptp`, which has been removed and replaced by `np.ptp(arr, ...)`. 

closes #262 

```
 __________ ERROR collecting mne/io/neuralynx/tests/test_neuralynx.py ___________
mne/io/neuralynx/tests/test_neuralynx.py:21: in <module>
    pytest.importorskip("neo")
/opt/hostedtoolcache/Python/3.13.7/x64/lib/python3.13/site-packages/neo/__init__.py:15: in <module>
    from neo.core import *
/opt/hostedtoolcache/Python/3.13.7/x64/lib/python3.13/site-packages/neo/core/__init__.py:35: in <module>
    from neo.core.block import Block
/opt/hostedtoolcache/Python/3.13.7/x64/lib/python3.13/site-packages/neo/core/block.py:12: in <module>
    from neo.core.container import Container, unique_objs
/opt/hostedtoolcache/Python/3.13.7/x64/lib/python3.13/site-packages/neo/core/container.py:13: in <module>
    from neo.core.spiketrain import SpikeTrain
/opt/hostedtoolcache/Python/3.13.7/x64/lib/python3.13/site-packages/neo/core/spiketrain.py:24: in <module>
    import quantities as pq
/opt/hostedtoolcache/Python/3.13.7/x64/lib/python3.13/site-packages/quantities/__init__.py:275: in <module>
    from . import quantity
/opt/hostedtoolcache/Python/3.13.7/x64/lib/python3.13/site-packages/quantities/quantity.py:113: in <module>
    class Quantity(np.ndarray):
/opt/hostedtoolcache/Python/3.13.7/x64/lib/python3.13/site-packages/quantities/quantity.py:632: in Quantity
    @with_doc(np.ndarray.ptp)
              ^^^^^^^^^^^^^^
E   AttributeError: type object 'numpy.ndarray' has no attribute 'ptp'
```