### PR TITLE
Fix inplace arithmetic operators for numpy>=2

### DIFF
--- a/quantities/quantity.py
+++ b/quantities/quantity.py
@@ -384,12 +384,12 @@ class Quantity(np.ndarray):
         # See:
         # - https://numpy.org/devdocs/release/2.0.0-notes.html#array-prepare-is-removed
         # - https://numpy.org/neps/nep-0013-ufunc-overrides.html
-        cself = self.copy()
-        cother = other.copy()
-        res = super().__imul__(other)
         if _np_version < (2, 0, 0):
-            return res
+            return super().__imul__(other)
         else:
+            cself = self.copy()
+            cother = other.copy()
+            res = super().__imul__(other)
             context = (np.multiply, (cself, cother, cself), 0)
             return self.__array_prepare__(res, context=context)
 
@@ -401,12 +401,12 @@ class Quantity(np.ndarray):
     @protected_multiplication
     def __itruediv__(self, other):
         # see comment above on __imul__
-        cself = self.copy()
-        cother = other.copy()
-        res = super().__itruediv__(other)
         if _np_version < (2, 0, 0):
-            return res
+            return super().__itruediv__(other)
         else:
+            cself = self.copy()
+            cother = other.copy()
+            res = super().__itruediv__(other)
             context = (np.true_divide, (cself, cother, cself), 0)
             return self.__array_prepare__(res, context=context)
 
@@ -424,12 +424,12 @@ class Quantity(np.ndarray):
     @protected_power
     def __ipow__(self, other):
         # see comment above on __imul__
-        cself = self.copy()
-        cother = other.copy()
-        res = super().__ipow__(other)
         if _np_version < (2, 0, 0):
-            return res
+            return super().__ipow__(other)
         else:
+            cself = self.copy()
+            cother = other.copy()
+            res = super().__ipow__(other)
             context = (np.power, (cself, cother, cself), 0)
             return self.__array_prepare__(res, context=context)
 

--- a/quantities/tests/test_arithmetic.py
+++ b/quantities/tests/test_arithmetic.py
@@ -367,11 +367,34 @@ class TestDTypes(TestCase):
         self.assertRaises(ValueError, op.isub, [1, 2, 3]*pq.m, pq.J)
         self.assertRaises(ValueError, op.isub, [1, 2, 3]*pq.m, 5*pq.J)
 
+    def test_in_place_multiplication(self):
+        velocity = 3 * pq.m/pq.s
+        time = 2 * pq.s
+
+        self.assertQuantityEqual(velocity * time, 6 * pq.m)
+
+        distance = velocity.copy()
+        distance *= time
+        self.assertQuantityEqual(distance, 6 * pq.m)
+
     def test_division(self):
         molar = pq.UnitQuantity('M',  1000 * pq.mole/pq.m**3, u_symbol='M')
         for subtr in [1, 1.0]:
             q = 1*molar/(1000*pq.mole/pq.m**3)
             self.assertQuantityEqual((q - subtr).simplified, 0)
+
+        a = np.array([5, 10, 15]) * pq.s
+        b = np.array([2, 4, 6]) * pq.kg
+
+        c = a / b
+        self.assertQuantityEqual(c, np.array([2.5, 2.5, 2.5]) * pq.s / pq.kg)
+
+    def test_in_place_division(self):
+        a = np.array([5, 10, 15]) * pq.s
+        b = np.array([2, 4, 6]) * pq.kg
+
+        a /= b
+        self.assertQuantityEqual(a, np.array([2.5, 2.5, 2.5]) * pq.s / pq.kg)
 
     def test_powering(self):
         # test raising a quantity to a power
@@ -403,3 +426,12 @@ class TestDTypes(TestCase):
         def ipow(q1, q2):
             q1 -= q2
         self.assertRaises(ValueError, ipow, 1*pq.m, [1, 2])
+
+    def test_inplace_powering(self):
+        a = 5.5 * pq.cm
+        a **= 5
+        self.assertQuantityEqual(a, (5.5**5) * (pq.cm**5))
+
+        b = np.array([1, 2, 3, 4, 5]) * pq.kg
+        b **= 3
+        self.assertQuantityEqual(b, np.array([1, 8, 27, 64, 125]) * pq.kg**3)


### PR DESCRIPTION
The reason for the broken in-place behaviour reported in #254 and #258 is that with NumPy 1.x, `super().__imul__(other)` calls `self.__array_prepare__(self, context)`, which calculates the correct units, but `_array_prepare__` was removed from NumPy in NumPy 2.0.

This is an inelegant quick fix, calling `self.__array_prepare__(self, context)` explicitly. It's inelegant because we have to reconstruct `context`, and we have similar code in multiple places. This will hopefully be enough to get a release out quickly, then we can revisit this when we have more time and fix it properly, probably by implementing `__array_ufunc__`.

See:
  - https://numpy.org/devdocs/release/2.0.0-notes.html#array-prepare-is-removed
  - https://numpy.org/neps/nep-0013-ufunc-overrides.html
