### PR TITLE
fix: preserve units for np.positive (unary plus)

### DIFF
--- a/quantities/dimensionality.py
+++ b/quantities/dimensionality.py
@@ -326,6 +326,7 @@ p_dict[np.fabs] = _d_copy
 p_dict[np.absolute] = _d_copy
 p_dict[np.conjugate] = _d_copy
 p_dict[np.negative] = _d_copy
+p_dict[np.positive] = _d_copy
 p_dict[np.ones_like] = _d_copy
 p_dict[np.rint] = _d_copy
 p_dict[np.floor] = _d_copy

--- a/quantities/tests/test_arithmetic.py
+++ b/quantities/tests/test_arithmetic.py
@@ -185,6 +185,20 @@ class TestDTypes(TestCase):
             Quantity(5.0, 'm')
         )
 
+    def test_positive(self):
+        self.assertQuantityEqual(
+            +pq.m,
+            Quantity(1, 'm')
+        )
+        self.assertQuantityEqual(
+            +Quantity(5, 'm'),
+            Quantity(5, 'm')
+        )
+        self.assertQuantityEqual(
+            +Quantity(-5.0, 'm'),
+            Quantity(-5.0, 'm')
+        )
+
     def test_addition(self):
         self.assertQuantityEqual(
             pq.eV + pq.eV,


### PR DESCRIPTION
Applying unary `+` to a Quantity raised `ValueError: ufunc 'positive' not supported` because `np.positive` had no dimensionality handler; registering it with `_d_copy` makes it preserve units like `np.negative`. Closes #94.